### PR TITLE
RoFILib: Implement emptyDockFill

### DIFF
--- a/RoFILib/configuration/Configuration.cpp
+++ b/RoFILib/configuration/Configuration.cpp
@@ -263,6 +263,24 @@ bool Configuration::addEdge(const Edge& edge) {
     return true;
 }
 
+bool Configuration::removeEdge(const Edge& edge) {
+    // Finds edges for both modules.
+    EdgeList& set1 = edges.at(edge.id1());
+    EdgeList& set2 = edges.at(edge.id2());
+
+    int index1 = edge.side1() * 3 + edge.dock1();
+    int index2 = edge.side2() * 3 + edge.dock2();
+    if (!set1[index1].has_value() || !set2[index2].has_value())
+        return false;
+
+    if (set1[index1].value() != edge || set2[index2].value() != reverse(edge))
+        return false;
+
+    set1[index1] = {};
+    set2[index2] = {};
+    return true;
+}
+
 bool Configuration::findEdge(const Edge& edge) const {
     int idx = edge.side1() * 3 + edge.dock1();
     return edges.at(edge.id1())[idx].has_value();

--- a/RoFILib/configuration/Configuration.h
+++ b/RoFILib/configuration/Configuration.h
@@ -268,6 +268,7 @@ public:
 
     // Adds given edge to given modules if both docks are free.
     bool addEdge(const Edge& edge);
+    bool removeEdge(const Edge& edge);
 
     bool findEdge(const Edge& edge) const;
     bool findConnection(const Edge& edge) const;

--- a/RoFILib/util/CMakeLists.txt
+++ b/RoFILib/util/CMakeLists.txt
@@ -9,3 +9,6 @@ endif(${LIBCXX})
 
 add_executable(topology2dot topology2dot.cpp)
 target_link_libraries(topology2dot PUBLIC configuration)
+
+add_executable(emptyDockFill emptyDockFill.cpp)
+target_link_libraries(emptyDockFill PUBLIC configuration generators)

--- a/RoFILib/util/emptyDockFill.cpp
+++ b/RoFILib/util/emptyDockFill.cpp
@@ -1,0 +1,104 @@
+#include <Configuration.h>
+#include <IO.h>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <optional>
+
+std::string createName(const Edge& edge, int alpha, int beta, int gamma) {
+    std::stringstream out;
+    out << "|" << alpha/90 << beta/90 << gamma/90 <<
+        IO::toString(edge.side1()) <<
+        IO::toString(edge.dock1()) <<
+        IO::toString(edge.ori()) <<
+        IO::toString(edge.dock2()) <<
+        IO::toString(edge.side2()) <<
+        edge.id2();
+    return out.str();
+}
+
+void printConfig(const Configuration& config, const std::string& name,  const std::string& dirpath) {
+    std::ofstream output;
+    std::string outputPath = dirpath + name + ".in";
+    output.open(outputPath.c_str());
+    if(!output) {
+        std::cout << "Could not open output file" << std::endl;
+    }
+
+    output << IO::toString(config);
+    output.close();
+}
+
+void fillWithAngles(Configuration config, ID curr_id, int alpha, int beta, int gamma, const std::string& dirpath) {
+    config.addModule(alpha, beta, gamma, curr_id);
+    for (const auto& [to_id, _module] : config.getModules()) {
+        if (to_id == curr_id)
+            continue;
+        std::optional<Edge> curr_edge = std::make_optional<Edge>(curr_id, A, XPlus, 0, XPlus, A, to_id);
+        while (curr_edge.has_value()) {
+            if (config.addEdge(curr_edge.value())) {
+                if (config.isValid()) {
+                    auto name = createName(curr_edge.value(), alpha, beta, gamma);
+                    printConfig(config, name, dirpath);
+                }
+                config.removeEdge(curr_edge.value());
+            }
+            curr_edge = nextEdge(curr_edge.value());
+        }
+    }
+}
+
+ID getMaxId(const Configuration& config) {
+    ID max = -1;
+    for (const auto& [to_id, _module] : config.getModules()) {
+        if (max < to_id)
+            max = to_id;
+    }
+    return max;
+}
+
+void emptyDockFill(Configuration& config, const std::string& dirpath) {
+    auto curr_id  = getMaxId(config) + 1;
+    config.addModule(0, 0, 0, curr_id);
+    for (int alpha : {-90, 0, 90}) {
+        for (int beta : {-90, 0, 90}) {
+            for (int gamma : {-90, 0, 90, 180}) {
+                fillWithAngles(config, curr_id, alpha, beta, gamma, dirpath);
+            }
+        }
+    }
+}
+
+void printHelp() {
+    std::cout << "Correct use:" << std::endl;
+    std::cout << "\t./emptyDockFill [pathToInput] [pathToOutputDir/]" << std::endl;
+}
+
+int main(int argc, char* argv[]) {
+
+    if (argc != 3) {
+        std::cout << "Incorrect use of tool." << std::endl;
+        printHelp();
+        return 1;
+    }
+
+    std::ifstream input;
+    input.open(argv[1]);
+    if(!input) {
+        std::cout << "Could not open input file" << std::endl;
+        return 1;
+    }
+
+    Configuration config;
+    if(!IO::readConfiguration(input, config)) {
+        std::cout << "Could not read config" << std::endl;
+        return 1;
+    }
+    input.close();
+    std::string dirpath(argv[2]);
+    std::string name(argv[1]);
+    dirpath += name.substr(name.find_last_of("\\/") + 1, name.size());
+    dirpath.erase(dirpath.size() - 3);
+    emptyDockFill(config, dirpath);
+    return 0;
+}


### PR DESCRIPTION
New utility. Given path to configuration (`config`) a path to directory (`dir`), fills `dir` with all configurations that they have `config` as subconfig, but they have one more module.