### PR TITLE
RoFILib: Remove faulty logic fixing spanning tree

### DIFF
--- a/RoFILib/configuration/Configuration.cpp
+++ b/RoFILib/configuration/Configuration.cpp
@@ -334,7 +334,7 @@ bool Configuration::removeEdge(const Edge& edge) {
     return true;
 }
 
-bool Configuration::removeSpanningEdge(ID parent, ID child) {
+void Configuration::removeSpanningEdge(ID parent, ID child) {
     for (int i = 0; i < 6; ++i) {
         auto& succOpt = spanningSucc[parent][i];
         if (!succOpt.has_value())
@@ -347,31 +347,10 @@ bool Configuration::removeSpanningEdge(ID parent, ID child) {
     }
 
     spanningPred[child] = {};
-    for (auto& edgeOpt : spanningCross.at(child)) {
-        if (!edgeOpt.has_value())
-            continue;
-        ID nextId = edgeOpt.value().id2();
-        if (spanningPred[nextId].has_value()
-            && spanningPred[nextId].value().first == child)
-            continue;
-        for (int i = 0; i < 6; ++i) {
-            auto& succOpt = spanningSucc[nextId][i];
-            if (succOpt.has_value())
-                continue;
-            succOpt = {reverse(edgeOpt.value())};
-            spanningSuccCount[nextId] += 1;
-            spanningPred[child] = {std::make_pair(nextId, edgeOpt.value().side1())};
-            int toDeleteIndex = edgeOpt.value().side2() * 3 + edgeOpt.value().dock2();
-            spanningCross[nextId][toDeleteIndex] = {};
-            edgeOpt = {};
-            return true;
-        }
-    }
 
-    if (connectedVal == Value::True)
-        connectedVal = Value::Unknown;
+    connectedVal = Value::Unknown;
     spanningTreeComputed = false;
-    return false;
+    return;
 }
 
 bool Configuration::findEdge(const Edge& edge) const {

--- a/RoFILib/configuration/Configuration.h
+++ b/RoFILib/configuration/Configuration.h
@@ -391,7 +391,7 @@ private:
      *
      * \returns `True` if it succeeded fixing, `False` if not.
      */
-    bool removeSpanningEdge(ID parent, ID child);
+    void removeSpanningEdge(ID parent, ID child);
 
     void spanningClearId(ID id);
 


### PR DESCRIPTION
Ive realised that I make no difference between cross and forward edges, so my logic about local fixing spanning tree was faulty.