### PR TITLE
releng: Replace non-POSIX argument passed to find

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -104,7 +104,7 @@ run() {
 
     export PATH=$(realpath releng/tools):$ORIGINAL_PATH
     ## Add bin directories of the suites to path
-    for suite in $(find suites -maxdepth 1 -type d -printf '%f\n'); do
+    for suite in $(find suites -maxdepth 1 -type d -exec basename {} \;); do
         export PATH="${ROFI_BUILD_DIR}/$suite/bin:$PATH"
     done
 


### PR DESCRIPTION
Argument `-printf '%f\n'`, which is not in POSIX, was passed to `find`, causing the `setup.sh` to fail on MacOS.