### PR TITLE
simulator: Add Python bindings for HAL

### DIFF
--- a/doc/intro/compiling.rst
+++ b/doc/intro/compiling.rst
@@ -207,3 +207,9 @@ In a different terminal, run the module code for each module that you want to co
 
     $ source setup.sh -f Debug # Setup your terminal
     🤖 D $ basicJointPosition  # Run the compiled module code
+
+If you are interested in controlling the simulation via Python instead of C++,
+you can follow example `examples/simulator/pythonInterface`:
+
+.. code-block:: sh
+    🤖 D $ python3 examples/simulator/pythonInterface/oscilate.py

--- a/examples/simulator/pythonInterface/oscilate.py
+++ b/examples/simulator/pythonInterface/oscilate.py
@@ -1,0 +1,23 @@
+from pyRofiHal import RoFI
+import threading
+from math import radians
+
+"""
+Simple showcase that possesses one of the RoFIs in simulation, chooses the first
+joint and moves it between its limits forever.
+"""
+
+def run():
+    r = RoFI.getLocal() # Or use RoFI.getRemote(<id>) to get a specific RoFI
+    j = r.getJoint(0)
+    event = threading.Event()
+    while True:
+        event.clear()
+        j.setPosition(j.minPosition, radians(90), lambda j: event.set())
+        event.wait()
+        event.clear()
+        j.setPosition(j.maxPosition, radians(90), lambda j: event.set())
+        event.wait()
+
+if __name__ == "__main__":
+    run()

--- a/examples/simulator/pythonInterface/readme.md
+++ b/examples/simulator/pythonInterface/readme.md
@@ -1,0 +1,18 @@
+# RoFI HAL Python bindings
+
+This example shows you how to use Python bindings for the RoFI HAL interface. It
+allows you to control the modules in Gazebo or Simplesim simulation via Python
+without a need to write any C++ code.
+
+## How to run it:
+
+First, make sure that you have setup the RoFI environment. Then start gazebo and
+the script `oscilate.py`:
+
+```
+$ source setup.sh -f Debug              # Setup your terminal for compiling RoFI in Debug mode.
+🤖 D $ rcfg desktop                     # Configure the desktop suite
+🤖 D $ rmake --all                      # Build everything you have configured
+🤖 D $ gazebo worlds/two_modules.world  # Run gazebo. We recommend using --verbose for more info
+🤖 D $ python3 examples/pythonInterface/oscialte.py
+```

--- a/setup.sh
+++ b/setup.sh
@@ -125,6 +125,7 @@ run() {
     export PS1 # Bring shell variable into env, so we can back it up
     backup PS1
     backup PATH
+    backup PYTHONPATH
 
     setGazeboVariables
 
@@ -164,9 +165,7 @@ run() {
     export ROFI_BUILD_DIR="$(pwd)/build.${ROFI_BUILD_CONFIGURATION}"
 
     export GAZEBO_MODEL_PATH="$ROFI_ROOT/data/gazebo/models:$GAZEBO_MODEL_PATH"
-    export GAZEBO_PLUGIN_PATH="$ROFI_BUILD_DIR/desktop/gazebosim/rofiModule:$GAZEBO_PLUGIN_PATH"
-    export GAZEBO_PLUGIN_PATH="$ROFI_BUILD_DIR/desktop/gazebosim/roficom:$GAZEBO_PLUGIN_PATH"
-    export GAZEBO_PLUGIN_PATH="$ROFI_BUILD_DIR/desktop/gazebosim/distributor:$GAZEBO_PLUGIN_PATH"
+    export GAZEBO_PLUGIN_PATH="$ROFI_BUILD_DIR/desktop/lib:$GAZEBO_PLUGIN_PATH"
     export GAZEBO_RESOURCE_PATH="$ROFI_ROOT/data/gazebo:$GAZEBO_RESOURCE_PATH"
     export GAZEBO_RESOURCE_PATH="$ROFI_BUILD_DIR/desktop/data/gazebo:$GAZEBO_RESOURCE_PATH"
 
@@ -175,6 +174,7 @@ run() {
     ## Add bin directories of the suites to path
     for suite in $(find suites -maxdepth 1 -type d -exec basename {} \;); do
         export PATH="${ROFI_BUILD_DIR}/$suite/bin:$PATH"
+        export PYTHONPATH="${ROFI_BUILD_DIR}/$suite/lib:$PYTHONPATH"
     done
 
     ## Register tab completion

--- a/softwareComponents/rofiHalSimPy/CMakeLists.txt
+++ b/softwareComponents/rofiHalSimPy/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.11)
+
+
+pybind11_add_module(pyRofiHal hal.cpp)
+target_link_libraries(pyRofiHal PRIVATE rofiHal)

--- a/softwareComponents/rofiHalSimPy/hal.cpp
+++ b/softwareComponents/rofiHalSimPy/hal.cpp
@@ -1,0 +1,89 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/functional.h>
+
+#include <rofi_hal.hpp>
+
+namespace py = pybind11;
+
+using namespace rofi::hal;
+
+PYBIND11_MODULE( pyRofiHal, m ) {
+    m.doc() = "RoFI simulator HAL";
+
+    py::class_< Joint > joint( m, "Joint" );
+    joint
+        .def_property_readonly( "maxPosition", &Joint::maxPosition )
+        .def_property_readonly( "minPosition", &Joint::minPosition )
+        .def_property_readonly( "maxSpeed", &Joint::maxSpeed )
+        .def_property_readonly( "minSpeed", &Joint::minSpeed )
+        .def_property_readonly( "maxTorque", &Joint::maxTorque )
+        .def_property_readonly( "velocity", &Joint::getVelocity )
+        .def_property_readonly( "torque", &Joint::getTorque )
+        .def_property_readonly( "position", &Joint::getPosition )
+        .def( "setVelocity", &Joint::setVelocity )
+        .def( "setTorque", &Joint::setTorque )
+        .def( "setPosition", &Joint::setPosition )
+        .def( "onError", &Joint::onError );
+
+    py::enum_< Joint::Error >( joint, "Error" )
+        .value( "Communication", Joint::Error::Communication )
+        .value( "Hardware", Joint::Error::Hardware )
+        .export_values();
+
+    py::enum_< ConnectorPosition >( m, "ConnectorPosition" )
+        .value( "Retracted", ConnectorPosition::Retracted )
+        .value( "Extended", ConnectorPosition::Extended )
+        .export_values();
+
+    py::enum_< ConnectorOrientation >( m, "ConnectorOrientation" )
+        .value( "North", ConnectorOrientation::North )
+        .value( "East", ConnectorOrientation::East )
+        .value( "South", ConnectorOrientation::South )
+        .value( "West", ConnectorOrientation::West )
+        .export_values();
+
+    py::enum_< ConnectorLine >( m, "ConnectorLine" )
+        .value( "Internal", ConnectorLine::Internal )
+        .value( "External", ConnectorLine::External )
+        .export_values();
+
+    py::enum_< ConnectorEvent >( m, "ConnectorEvent" )
+        .value( "Connected", ConnectorEvent::Connected )
+        .value( "Disconnected", ConnectorEvent::Disconnected )
+        .value( "ConnectedPower", ConnectorEvent::ConnectedPower )
+        .value( "DisconnectedPower", ConnectorEvent::DisconnectedPower )
+        .export_values();
+
+    py::class_< ConnectorState >( m, "ConnectorState" )
+        .def_readwrite( "position", &ConnectorState::position )
+        .def_readwrite( "internal", &ConnectorState::internal )
+        .def_readwrite( "external", &ConnectorState::external )
+        .def_readwrite( "connected", &ConnectorState::connected )
+        .def_readwrite( "orientation", &ConnectorState::orientation );
+
+    py::class_< Connector >( m, "Connector" )
+        .def_property_readonly( "state", &Connector::getState )
+        .def( "connect", &Connector::connect )
+        .def( "disconnect", &Connector::disconnect )
+        .def( "onConnectorEvent", &Connector::onConnectorEvent )
+        .def( "onPacket", &Connector::onPacket )
+        .def( "send", &Connector::send );
+        // TODO: This causes undefined symbol at runtime
+        // .def( "connectPower", &Connector::connectPower )
+        // .def( "disconnectPower", &Connector::disconnectPower );
+
+    py::class_< RoFI > rofiC( m, "RoFI" );
+    rofiC
+        .def_property_readonly( "id", &RoFI::getId )
+        .def( "getJoint", &RoFI::getJoint )
+        .def( "getConnector", &RoFI::getConnector )
+        .def_property_readonly( "descriptor", &RoFI::getDescriptor )
+        .def( "wait", &RoFI::wait )
+        .def_static( "getLocal", &RoFI::getLocalRoFI )
+        .def_static( "getRemote", &RoFI::getRemoteRoFI );
+
+    py::class_< RoFI::Descriptor >( rofiC, "Descriptor" )
+        .def_readwrite( "jointCount", &RoFI::Descriptor::jointCount )
+        .def_readwrite( "connectorCount", &RoFI::Descriptor::connectorCount );
+}

--- a/suites/desktop/CMakeLists.txt
+++ b/suites/desktop/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{ROFI_ROOT}/releng/cmake)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 
 include(FetchContent)
 include(CollectTargets)
@@ -61,6 +62,18 @@ if(NOT fmt_POPULATED)
   add_subdirectory(${fmt_SOURCE_DIR} ${fmt_BINARY_DIR})
 endif()
 
+FetchContent_Declare(
+  pybind11
+  GIT_REPOSITORY https://github.com/pybind/pybind11.git
+  GIT_TAG        v2.6.2
+)
+FetchContent_GetProperties(pybind11)
+if(NOT pybind11_POPULATED)
+  FetchContent_Populate(pybind11)
+  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
+  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${pybind11_SOURCE_DIR}/contrib")
+endif()
+
 find_package(gazebo REQUIRED)
 include_directories(${GAZEBO_INCLUDE_DIRS})
 link_directories(${GAZEBO_LIBRARY_DIRS})
@@ -81,8 +94,10 @@ add_component(jthread)
 add_component(rofisimMessages)
 add_component(configurationMessages)
 add_component(rofiHalSim)
+add_component(rofiHalSimPy)
 add_component(gazebosim)
 add_component(simplesim)
+
 
 if (NOT ${BUILD_HEADLESS})
   add_tool(visualizer)


### PR DESCRIPTION
Add simple Python bindings for HAL. Note that in the future, we will have to restructure the bindings once we add bindings for configuration & other algorithms. However, I would postpone the decision about the structure.