### PR TITLE
rofi-tool: fix segfault

### DIFF
--- a/tools/rofiTool/check.hpp
+++ b/tools/rofiTool/check.hpp
@@ -1,7 +1,7 @@
 #include <dimcli/cli.h>
 #include <universalModule.hpp>
 
-static auto& command = Dim::Cli().command( "check" )
+static auto command = Dim::Cli().command( "check" )
     .desc( "Check a given configuration" );
 static auto& inputFile = command.opt< std::string >( "<FILE>" )
     .desc("Specify configuration file");

--- a/tools/rofiTool/preview.cpp
+++ b/tools/rofiTool/preview.cpp
@@ -170,7 +170,7 @@ void buildConfigurationScene( vtkRenderer* renderer, rofi::Rofibot& bot ) {
     }
 }
 
-static auto& command = Dim::Cli().command( "preview" )
+static auto command = Dim::Cli().command( "preview" )
     .desc( "Interactively preview a configuration" );
 static auto& inputFile = command.opt< std::string >( "<FILE>" )
     .desc("Specify source file");


### PR DESCRIPTION
Without this order, the command crashed with the following trace for me for some reason:

    #0  0x00007fcfad22ccbf in std::__detail::_List_node_base::_M_hook(std::__detail::_List_node_base*) () from /nix/store/0kiykyrnrpfhmjwxwx89kxr20hmf5304-gcc-10.3.0-lib/lib/libstdc++.so.6
    #1  0x0000000000440153 in std::__cxx11::list<std::unique_ptr<Dim::Cli::OptBase, std::default_delete<Dim::Cli::OptBase> >, std::allocator<std::unique_ptr<Dim::Cli::OptBase, std::default_delete<Dim::Cli::OptBase> > > >::_M_insert<std::unique_ptr<Dim::Cli::OptBase, std::default_delete<Dim::Cli::OptBase> > > (__position=..., this=0x7fff58df5700)
        at /nix/store/dlni53myj53kx20pi4yhm7p68lw17b07-gcc-10.3.0/include/c++/10.3.0/bits/stl_list.h:1912
    #2  std::__cxx11::list<std::unique_ptr<Dim::Cli::OptBase, std::default_delete<Dim::Cli::OptBase> >, std::allocator<std::unique_ptr<Dim::Cli::OptBase, std::default_delete<Dim::Cli::OptBase> > > >::push_back (
        __x=..., this=0x7fff58df5700) at /nix/store/dlni53myj53kx20pi4yhm7p68lw17b07-gcc-10.3.0/include/c++/10.3.0/bits/stl_list.h:1217
    #3  Dim::Cli::addOpt (this=this@entry=0x7fff58df5640, src=std::unique_ptr<Dim::Cli::OptBase> = {...}) at /home/jtojnar/Projects/RoFI/build.Debug/desktop/_deps/dimcli-src/libs/dimcli/cli.cpp:1275
    #4  0x0000000000417b4c in Dim::Cli::addOpt<Dim::Cli::Opt<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > (this=this@entry=0x7fff58df5640,
        ptr=std::unique_ptr<Dim::Cli::Opt<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >> = {...})
        at /home/jtojnar/Projects/RoFI/build.Debug/desktop/_deps/dimcli-src/libs/dimcli/cli.h:763
    #5  0x0000000000417de3 in Dim::Cli::opt<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, void> (
        this=this@entry=0x7fff58df5640, value=value@entry=0x0, names="<FILE>", def="") at /home/jtojnar/Projects/RoFI/build.Debug/desktop/_deps/dimcli-src/libs/dimcli/cli.h:689
    #6  0x000000000041271e in Dim::Cli::opt<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (def="", names="<FILE>", this=0x7fff58df5640)
        at /home/jtojnar/Projects/RoFI/build.Debug/desktop/_deps/dimcli-src/libs/dimcli/cli.h:734
    #7  __static_initialization_and_destruction_0 (__priority=65535, __initialize_p=1) at /home/jtojnar/Projects/RoFI/tools/rofiTool/preview.cpp:175
    #8  0x0000000000477e45 in __libc_csu_init ()
    #9  0x00007fcface7670f in __libc_start_main (main=0x411e50 <main(int, char**)>, argc=3, argv=0x7fff58df5878, init=0x477e00 <__libc_csu_init>, fini=<optimized out>, rtld_fini=<optimized out>,
        stack_end=0x7fff58df5868) at ../csu/libc-start.c:279
    #10 0x0000000000413c3a in _start () at ../sysdeps/x86_64/start.S:120

See the upstream issue: https://github.com/gknowles/dimcli/issues/19
