### PR TITLE
configuration: Fix return type

### DIFF
--- a/softwareComponents/configuration/Configuration.cpp
+++ b/softwareComponents/configuration/Configuration.cpp
@@ -246,7 +246,7 @@ std::vector<Edge> Configuration::getEdges(ID id, const std::unordered_set<ID>& e
 }
 
 
-const std::unordered_map<ID, std::array<std::optional<Edge>, 6>> Configuration::getSpanningSucc() const {
+const std::unordered_map<ID, std::array<std::optional<Edge>, 6>>& Configuration::getSpanningSucc() const {
     return spanningSucc;
 }
 

--- a/softwareComponents/configuration/Configuration.h
+++ b/softwareComponents/configuration/Configuration.h
@@ -268,7 +268,7 @@ public:
     std::vector<Edge> getEdges(ID id) const;
     std::vector<Edge> getEdges(ID id, const std::unordered_set<ID>& exclude) const;
 
-    const std::unordered_map<ID, std::array<std::optional<Edge>, 6>> getSpanningSucc() const;
+    const std::unordered_map<ID, std::array<std::optional<Edge>, 6>>& getSpanningSucc() const;
     const std::unordered_map<ID, unsigned int>& getSpanningSuccCount() const;
     const std::unordered_map<ID, std::optional<std::pair<ID, ShoeId>>>& getSpanningPred() const;
 


### PR DESCRIPTION
All uses expected this to return the reference, not a new map (which resulted in some undefined behaviour).