### PR TITLE
Minor code improvements (atoms, configuration)

### DIFF
--- a/softwareComponents/atoms/include/atoms/containers.hpp
+++ b/softwareComponents/atoms/include/atoms/containers.hpp
@@ -104,14 +104,14 @@ class IdSet {
         void afterIncrement() {
             if ( _set->_elems.empty() )
                 return;
-            while ( !_it->has_value() && _it != _set->_elems.end() )
+            while ( _it != _set->_elems.end() && !_it->has_value() )
                 _it++;
         }
 
         void afterDecrement() {
             if ( _set->_elems.empty() )
                 return;
-            while( !_it->has_value() && _it != _set->_elems.begin() )
+            while( _it != _set->_elems.begin() && !_it->has_value() )
                 _it--;
         }
 

--- a/softwareComponents/configuration/rofibot.cpp
+++ b/softwareComponents/configuration/rofibot.cpp
@@ -20,6 +20,7 @@ double orientationToAngle( Orientation o ) {
 void rofi::Module::setJointParams( int idx, const Joint::Positions& p ) {
     // Currently we invalidate all positions; ToDo: think if we can improve it
     assert( idx < _joints.size() && idx >= 0 );
+    assert( p.size() == _joints[ idx ].joint->positions.size() );
     std::copy( p.begin(), p.end(), _joints[ idx ].joint->positions.begin() );
     _componentPosition = std::nullopt;
     if ( parent )


### PR DESCRIPTION
`ATOMS_CLONEABLE` requires an abstract base or derived class. `Module` is neither of those (so the code doesn't compile at the moment).