### PR TITLE
Migrate to myst

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN export IDF_PATH=$ROFI_TOOLS_PATH/esp-idf && \
     # When we use IDF, it brings python venv; thus if we want to build doc,
     # we have to install spinx and breathe into the venv
     . $IDF_PATH/export.sh && \
-    pip install sphinx breathe recommonmark sphinx_rtd_theme
+    pip install sphinx breathe myst_parser sphinx_rtd_theme
 
 # Newer Ubuntu (21.10) miss libdl.so which is (probably) required by VTK.
 # This is a temporary work-around until we migrate to VTK 9.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ author = 'Paradise'
 # ones.
 extensions = [
     'breathe',
-    'recommonmark',
+    'myst_parser',
 ]
 
 breathe_default_members = ('members', 'undoc-members')

--- a/doc/intro/suites/doc.rst
+++ b/doc/intro/suites/doc.rst
@@ -7,7 +7,7 @@ and Breathe.
 Dependencies
 ------------
 
-To build the documentation, Sphinx, Breathe, Sphinx-RTD-Theme, Recommonmark,
+To build the documentation, Sphinx, Breathe, Sphinx-RTD-Theme, MyST,
 Doxygen and Graphviz are required.
 
 On APT based system, these dependencies can be installed via:
@@ -15,7 +15,7 @@ On APT based system, these dependencies can be installed via:
 .. code-block:: sh
 
     $ apt-get install doxygen graphviz
-    $ pip3 install sphinx breathe sphinx-rtd-theme recommonmark
+    $ pip3 install sphinx breathe myst_parser sphinx-rtd-theme
 
 
 Build options

--- a/releng/cmake/Spinx.cmake
+++ b/releng/cmake/Spinx.cmake
@@ -24,7 +24,7 @@ if (NOT ${EXIT_CODE} EQUAL 0)
 endif()
 
 requirePythonModule(breathe)
-requirePythonModule(recommonmark)
+requirePythonModule(myst_parser)
 requirePythonModule(sphinx_rtd_theme)
 
 set(extractDoxygen ${CMAKE_COMMAND} -E env DOXYGEN="$<TARGET_FILE:Doxygen::doxygen>" "$ENV{ROFI_ROOT}/releng/doc/extractDoxygen.sh")

--- a/setup.sh
+++ b/setup.sh
@@ -105,7 +105,7 @@ setupIdf() {
     if [ $IDF_POST_INSTALL ]; then
         # When we use IDF, it brings python venv; thus if we want to build doc,
         # we have to install spinx and breathe into the venv
-        pip install sphinx breathe recommonmark sphinx_rtd_theme
+        pip install sphinx breathe myst_parser sphinx_rtd_theme
     fi
     IDF_POST_INSTALL=
 }


### PR DESCRIPTION
Recommonmark is discontinued and recomends MyST. (Both are for parsing markdown in sphinx.)

@yaqwsx Do you think you could update the docker image? (You can install there both myst_parser and recommonmark for now.)

Taken from #177 so it can be merged quicker, since it's not critical.