### PR TITLE
doc: Add note about inotify requirements

### DIFF
--- a/doc/intro/suites/doc.rst
+++ b/doc/intro/suites/doc.rst
@@ -18,6 +18,12 @@ On APT based system, these dependencies can be installed via:
     $ pip3 install sphinx breathe myst_parser sphinx-rtd-theme
 
 
+If you intend to use `rmake --doc` command, you need to install additional package
+
+.. code-block:: sh
+
+    $ apt-get install inotify-tools
+
 Build options
 -------------
 


### PR DESCRIPTION
In Ubuntu, `inotify-tools` are required for `rmake --doc`. Otherwise, the command fails with `ERROR: could not find 'inotifywait'. Aborting.`