### PR TITLE
Ubuntu22.04 build fail

### DIFF
--- a/softwareComponents/kinematics/fReconfig.hpp
+++ b/softwareComponents/kinematics/fReconfig.hpp
@@ -5,6 +5,7 @@
 #include <unordered_set>
 #include <map>
 #include <set>
+#include <memory>
 
 #include <legacy/configuration/Configuration.h>
 #include <legacy/configuration/IO.h>

--- a/suites/desktop/CMakeLists.txt
+++ b/suites/desktop/CMakeLists.txt
@@ -127,6 +127,9 @@ if (${BUILD_GAZEBO})
   # Workaround for bug in gazebo that causes problems on `g++11` with `-std=c++20`
   set(GAZEBO_INCLUDE_DIRS "$ENV{ROFI_ROOT}/gazebo_include" ${GAZEBO_INCLUDE_DIRS})
 
+  find_library(LibTBB NAMES tbb)
+  link_libraries(gazebo ${LibTBB})
+
   find_package(Protobuf REQUIRED)
   # Include Gazebo messages
   set(PROTOBUF_IMPORT_DIRS)


### PR DESCRIPTION
On Ubuntu 22.04 gcc 12 complains about missing header `<memory>` and build fails.