### PR TITLE
rofi-tool: Parse configuration from JSON

### DIFF
--- a/tools/rofiTool/CMakeLists.txt
+++ b/tools/rofiTool/CMakeLists.txt
@@ -4,6 +4,6 @@ project(rofi)
 add_resources(modelResources
     "model/body.obj" "model/connector.obj" "model/shoe.obj" "model/point.obj" )
 
-add_executable(rofi-tool main.cpp points.cpp preview.cpp build.cpp rendering.cpp check.cpp
+add_executable(rofi-tool main.cpp points.cpp preview.cpp build.cpp rendering.cpp check.cpp commands.cpp
     ${modelResources})
 target_link_libraries(rofi-tool PRIVATE dimcli configuration configurationWithJson isoreconfig ${VTK_LIBRARIES} atoms-heavy)

--- a/tools/rofiTool/CMakeLists.txt
+++ b/tools/rofiTool/CMakeLists.txt
@@ -6,4 +6,4 @@ add_resources(modelResources
 
 add_executable(rofi-tool main.cpp points.cpp preview.cpp build.cpp rendering.cpp check.cpp
     ${modelResources})
-target_link_libraries(rofi-tool PRIVATE dimcli configuration isoreconfig ${VTK_LIBRARIES} atoms-heavy)
+target_link_libraries(rofi-tool PRIVATE dimcli configuration configurationWithJson isoreconfig ${VTK_LIBRARIES} atoms-heavy)

--- a/tools/rofiTool/build.cpp
+++ b/tools/rofiTool/build.cpp
@@ -1,4 +1,4 @@
-#include "build.hpp"
+#include "commands.hpp"
 #include "rendering.hpp"
 #include <configuration/pad.hpp>
 #include <configuration/bots/umpad.hpp>

--- a/tools/rofiTool/build.cpp
+++ b/tools/rofiTool/build.cpp
@@ -80,7 +80,8 @@ int build( Dim::Cli & /* cli */ ) {
         rofi::configuration::matrices::Vector( { 0, 0, 0 } ),
         rofi::configuration::matrices::identity );
 
-    world.prepare();
+    world.prepare().get_or_throw_as< std::runtime_error >();
+        
     renderConfiguration( world, botTypeToString( static_cast< BotType >( *botType ) ) );
 
     return 0;

--- a/tools/rofiTool/build.hpp
+++ b/tools/rofiTool/build.hpp
@@ -1,3 +1,0 @@
-#include <dimcli/cli.h>
-
-int build( Dim::Cli & /* cli */ );

--- a/tools/rofiTool/check.cpp
+++ b/tools/rofiTool/check.cpp
@@ -1,5 +1,6 @@
 #include "check.hpp"
 #include <configuration/universalModule.hpp>
+#include <configuration/serialization.hpp>
 
 static auto command = Dim::Cli().command( "check" )
     .desc( "Check a given configuration" );
@@ -11,10 +12,20 @@ int check( Dim::Cli & /* cli */ ) {
     if ( !cfgFile.is_open() )
         throw std::runtime_error( "Cannot open file '" + *inputFile + "'" );
 
-    auto configuration = rofi::configuration::readOldConfigurationFormat( cfgFile );
-    rofi::configuration::connect< rofi::configuration::RigidJoint >(
-        configuration.getModule( 0 )->bodies()[ 0 ],
-        rofi::configuration::matrices::Vector( { 0, 0, 0 } ),
+    rofi::configuration::RofiWorld configuration;
+    if ( (*inputFile).ends_with( ".json" ) )
+        configuration = rofi::configuration::serialization::fromJSON( nlohmann::json::parse( cfgFile ) );
+    else 
+        configuration = rofi::configuration::readOldConfigurationFormat( cfgFile );
+
+    auto modules = configuration.modules();
+    if ( modules.size() == 0 ) 
+        throw std::runtime_error( "Configuration in file '" + *inputFile + "' does not contain any modules to display" );
+
+    const auto & firstModule = modules.begin()->module;
+    rofi::configuration::connect< rofi::configuration::RigidJoint >( 
+        firstModule->bodies().front(),
+        rofi::configuration::Vector( { 0, 0, 0 } ),
         rofi::configuration::matrices::identity );
 
     configuration.validate( rofi::configuration::SimpleCollision() ).get_or_throw_as< std::runtime_error >();

--- a/tools/rofiTool/check.cpp
+++ b/tools/rofiTool/check.cpp
@@ -1,6 +1,6 @@
-#include "check.hpp"
-#include <configuration/universalModule.hpp>
-#include <configuration/serialization.hpp>
+#include "commands.hpp"
+
+#include <configuration/rofiworld.hpp>
 
 static auto command = Dim::Cli().command( "check" )
     .desc( "Check a given configuration" );
@@ -8,27 +8,16 @@ static auto& inputFile = command.opt< std::string >( "<FILE>" )
     .desc("Specify configuration file");
 
 int check( Dim::Cli & /* cli */ ) {
-    auto cfgFile = std::ifstream( *inputFile );
-    if ( !cfgFile.is_open() )
-        throw std::runtime_error( "Cannot open file '" + *inputFile + "'" );
+    auto configuration = parseConfiguration( *inputFile );
 
-    rofi::configuration::RofiWorld configuration;
-    if ( (*inputFile).ends_with( ".json" ) )
-        configuration = rofi::configuration::serialization::fromJSON( nlohmann::json::parse( cfgFile ) );
-    else 
-        configuration = rofi::configuration::readOldConfigurationFormat( cfgFile );
+    // Empty configuration is valid
+    if ( configuration.modules().size() == 0 )
+        return 0;
 
-    auto modules = configuration.modules();
-    if ( modules.size() == 0 ) 
-        throw std::runtime_error( "Configuration in file '" + *inputFile + "' does not contain any modules to display" );
-
-    const auto & firstModule = modules.begin()->module;
-    rofi::configuration::connect< rofi::configuration::RigidJoint >( 
-        firstModule->bodies().front(),
-        rofi::configuration::Vector( { 0, 0, 0 } ),
-        rofi::configuration::matrices::identity );
+    affixConfiguration( configuration );
 
     configuration.validate( rofi::configuration::SimpleCollision() ).get_or_throw_as< std::runtime_error >();
+
     return 0;
 }
 

--- a/tools/rofiTool/check.hpp
+++ b/tools/rofiTool/check.hpp
@@ -1,3 +1,0 @@
-#include <dimcli/cli.h>
-
-int check( Dim::Cli & /* cli */ );

--- a/tools/rofiTool/commands.cpp
+++ b/tools/rofiTool/commands.cpp
@@ -1,0 +1,34 @@
+#include "commands.hpp"
+
+#include <fstream>
+#include <stdexcept>
+
+#include <configuration/rofiworld.hpp>
+#include <configuration/universalModule.hpp>
+#include <configuration/serialization.hpp>
+
+rofi::configuration::RofiWorld parseConfiguration( const std::string& inputFile )
+{
+    auto cfgFile = std::ifstream( inputFile );
+    if ( !cfgFile.is_open() )
+        throw std::runtime_error( "Cannot open file '" + inputFile + "'" );
+
+    rofi::configuration::RofiWorld configuration;
+    if ( inputFile.ends_with( ".json" ) )
+        configuration = rofi::configuration::serialization::fromJSON( nlohmann::json::parse( cfgFile ) );
+    else 
+        configuration = rofi::configuration::readOldConfigurationFormat( cfgFile );
+
+    return configuration;
+}
+
+void affixConfiguration( rofi::configuration::RofiWorld& configuration )
+{
+    auto modules = configuration.modules();
+    assert( modules.size() > 0 );
+    const auto & firstModule = modules.begin()->module;
+    rofi::configuration::connect< rofi::configuration::RigidJoint >( 
+        firstModule->bodies().front(),
+        rofi::configuration::Vector( { 0, 0, 0 } ),
+        rofi::configuration::matrices::identity );
+}

--- a/tools/rofiTool/commands.hpp
+++ b/tools/rofiTool/commands.hpp
@@ -1,0 +1,25 @@
+#include <dimcli/cli.h>
+#include <configuration/rofiworld.hpp>
+
+int build( Dim::Cli & /* cli */ );
+int check( Dim::Cli & /* cli */ );
+int points( Dim::Cli & /* cli */ );
+int preview( Dim::Cli & /* cli */ );
+
+/**
+ * @brief Parses configuration from given <inputFile>.
+ * If file has .json extension, assumes the JSON format of configuration;
+ * otherwise assumes the configuration is in the old (viki) format.
+ * Throws an error if the format is not recognized.
+ * @param inputFile File containing the configuration.
+ * @return Returns the parsed configuration.
+ */
+rofi::configuration::RofiWorld parseConfiguration( const std::string& inputFile );
+
+/**
+ * @brief Affixes given <configuration> in space using a RigidJoint between
+ * (0, 0, 0) and first found module.
+ * Assumes the configuration is not empty.
+ * @param configuration Configuration to be affixed in space.
+ */
+void affixConfiguration( rofi::configuration::RofiWorld& configuration );

--- a/tools/rofiTool/main.cpp
+++ b/tools/rofiTool/main.cpp
@@ -1,9 +1,6 @@
 #include <dimcli/cli.h>
 #include <iostream>
-#include "points.hpp"
-#include "preview.hpp"
-#include "check.hpp"
-#include "build.hpp"
+#include "commands.hpp"
 
 int main( int argc, char * argv[] ) {
     Dim::Cli cli;

--- a/tools/rofiTool/points.cpp
+++ b/tools/rofiTool/points.cpp
@@ -1,12 +1,7 @@
-#include "points.hpp"
+#include "commands.hpp"
 #include "rendering.hpp"
 
-#include <fstream>
-#include <stdexcept>
-
 #include <configuration/rofiworld.hpp>
-#include <configuration/universalModule.hpp>
-#include <configuration/serialization.hpp>
 
 static auto command = Dim::Cli().command( "points" )
     .desc( "Interactively preview a set of points defining the configuration" );
@@ -16,25 +11,12 @@ static auto& showModules = command.opt< bool >( "modules" )
     .desc( "Show with modules" );
 
 int points( Dim::Cli & /* cli */ ) {
-    auto cfgFile = std::ifstream( *inputFile );
-    if ( !cfgFile.is_open() )
-        throw std::runtime_error( "Cannot open file '" + *inputFile + "'" );
+    auto configuration = parseConfiguration( *inputFile );
+    
+    if ( configuration.modules().size() == 0 )
+        throw std::runtime_error( "Configuration in '" + *inputFile + "' does not contain any modules to decompose into points" );
 
-    rofi::configuration::RofiWorld configuration;
-    if ( (*inputFile).ends_with( ".json" ) )
-        configuration = rofi::configuration::serialization::fromJSON( nlohmann::json::parse( cfgFile ) );
-    else 
-        configuration = rofi::configuration::readOldConfigurationFormat( cfgFile );
-
-    auto modules = configuration.modules();
-    if ( modules.size() == 0 ) 
-        throw std::runtime_error( "Configuration in file '" + *inputFile + "' does not contain any modules to display" );
-
-    const auto & firstModule = modules.begin()->module;
-    rofi::configuration::connect< rofi::configuration::RigidJoint >( 
-        firstModule->bodies().front(),
-        rofi::configuration::Vector( { 0, 0, 0 } ),
-        rofi::configuration::matrices::identity );
+    affixConfiguration( configuration );
 
     configuration.prepare().get_or_throw_as< std::runtime_error >();
 

--- a/tools/rofiTool/points.cpp
+++ b/tools/rofiTool/points.cpp
@@ -6,6 +6,7 @@
 
 #include <configuration/rofiworld.hpp>
 #include <configuration/universalModule.hpp>
+#include <configuration/serialization.hpp>
 
 static auto command = Dim::Cli().command( "points" )
     .desc( "Interactively preview a set of points defining the configuration" );
@@ -19,12 +20,23 @@ int points( Dim::Cli & /* cli */ ) {
     if ( !cfgFile.is_open() )
         throw std::runtime_error( "Cannot open file '" + *inputFile + "'" );
 
-    auto configuration = rofi::configuration::readOldConfigurationFormat( cfgFile );
-    rofi::configuration::connect< rofi::configuration::RigidJoint >(
-        configuration.modules().begin()->module->bodies()[ 0 ],
-        rofi::configuration::matrices::Vector( { 0, 0, 0 } ),
+    rofi::configuration::RofiWorld configuration;
+    if ( (*inputFile).ends_with( ".json" ) )
+        configuration = rofi::configuration::serialization::fromJSON( nlohmann::json::parse( cfgFile ) );
+    else 
+        configuration = rofi::configuration::readOldConfigurationFormat( cfgFile );
+
+    auto modules = configuration.modules();
+    if ( modules.size() == 0 ) 
+        throw std::runtime_error( "Configuration in file '" + *inputFile + "' does not contain any modules to display" );
+
+    const auto & firstModule = modules.begin()->module;
+    rofi::configuration::connect< rofi::configuration::RigidJoint >( 
+        firstModule->bodies().front(),
+        rofi::configuration::Vector( { 0, 0, 0 } ),
         rofi::configuration::matrices::identity );
-    configuration.prepare();
+
+    configuration.prepare().get_or_throw_as< std::runtime_error >();
 
     renderPoints( configuration, *inputFile, *showModules );
 

--- a/tools/rofiTool/points.hpp
+++ b/tools/rofiTool/points.hpp
@@ -1,3 +1,0 @@
-#include <dimcli/cli.h>
-
-int points( Dim::Cli & /* cli */ );

--- a/tools/rofiTool/preview.cpp
+++ b/tools/rofiTool/preview.cpp
@@ -6,6 +6,7 @@
 
 #include <configuration/rofiworld.hpp>
 #include <configuration/universalModule.hpp>
+#include <configuration/serialization.hpp>
 
 static auto command = Dim::Cli().command( "preview" )
     .desc( "Interactively preview a configuration" );
@@ -17,12 +18,23 @@ int preview( Dim::Cli & /* cli */ ) {
     if ( !cfgFile.is_open() )
         throw std::runtime_error( "Cannot open file '" + *inputFile + "'" );
 
-    auto configuration = rofi::configuration::readOldConfigurationFormat( cfgFile );
-    rofi::configuration::connect< rofi::configuration::RigidJoint >(
-        configuration.modules().begin()->module->bodies()[ 0 ],
-        rofi::configuration::matrices::Vector( { 0, 0, 0 } ),
+    rofi::configuration::RofiWorld configuration;
+    if ( (*inputFile).ends_with( ".json" ) )
+        configuration = rofi::configuration::serialization::fromJSON( nlohmann::json::parse( cfgFile ) );
+    else 
+        configuration = rofi::configuration::readOldConfigurationFormat( cfgFile );
+
+    auto modules = configuration.modules();
+    if ( modules.size() == 0 ) 
+        throw std::runtime_error( "Configuration in file '" + *inputFile + "' does not contain any modules to display" );
+
+    const auto & firstModule = modules.begin()->module;
+    rofi::configuration::connect< rofi::configuration::RigidJoint >( 
+        firstModule->bodies().front(),
+        rofi::configuration::Vector( { 0, 0, 0 } ),
         rofi::configuration::matrices::identity );
-    configuration.prepare();
+
+    configuration.prepare().get_or_throw_as< std::runtime_error >();
 
     renderConfiguration( configuration, *inputFile );
 

--- a/tools/rofiTool/preview.cpp
+++ b/tools/rofiTool/preview.cpp
@@ -1,12 +1,10 @@
-#include "preview.hpp"
+#include "commands.hpp"
 #include "rendering.hpp"
 
 #include <fstream>
 #include <stdexcept>
 
 #include <configuration/rofiworld.hpp>
-#include <configuration/universalModule.hpp>
-#include <configuration/serialization.hpp>
 
 static auto command = Dim::Cli().command( "preview" )
     .desc( "Interactively preview a configuration" );
@@ -14,25 +12,12 @@ static auto& inputFile = command.opt< std::string >( "<FILE>" )
     .desc("Specify source file");
 
 int preview( Dim::Cli & /* cli */ ) {
-    auto cfgFile = std::ifstream( *inputFile );
-    if ( !cfgFile.is_open() )
-        throw std::runtime_error( "Cannot open file '" + *inputFile + "'" );
+    auto configuration = parseConfiguration( *inputFile );
 
-    rofi::configuration::RofiWorld configuration;
-    if ( (*inputFile).ends_with( ".json" ) )
-        configuration = rofi::configuration::serialization::fromJSON( nlohmann::json::parse( cfgFile ) );
-    else 
-        configuration = rofi::configuration::readOldConfigurationFormat( cfgFile );
+    if ( configuration.modules().size() == 0 )
+        throw std::runtime_error( "Configuration in '" + *inputFile + "' does not contain any modules to display" );
 
-    auto modules = configuration.modules();
-    if ( modules.size() == 0 ) 
-        throw std::runtime_error( "Configuration in file '" + *inputFile + "' does not contain any modules to display" );
-
-    const auto & firstModule = modules.begin()->module;
-    rofi::configuration::connect< rofi::configuration::RigidJoint >( 
-        firstModule->bodies().front(),
-        rofi::configuration::Vector( { 0, 0, 0 } ),
-        rofi::configuration::matrices::identity );
+    affixConfiguration( configuration );
 
     configuration.prepare().get_or_throw_as< std::runtime_error >();
 

--- a/tools/rofiTool/preview.hpp
+++ b/tools/rofiTool/preview.hpp
@@ -1,3 +1,0 @@
-#include <dimcli/cli.h>
-
-int preview( Dim::Cli & /* cli */ );


### PR DESCRIPTION
Provides the ability to use commands check, points and preview from rofi-tool on configurations in the JSON format (file with .json extension); contained in the first commit.
Second commit is a suggestion to merge headers and extract the common functionality of these commands into auxiliary functions.