### PR TITLE
configuration: Check joint limits when setting joint positions

### DIFF
--- a/softwareComponents/configuration/include/configuration/rofiworld.hpp
+++ b/softwareComponents/configuration/include/configuration/rofiworld.hpp
@@ -190,6 +190,23 @@ public:
     void setJointPositions( int idx, std::span< const float > p );
     // Implemented in CPP files as it depends on definition of RofiWorld
 
+    /**
+     * \brief Changes parameters of joint positions by values in <diff>.
+     * 
+     * Assumes <idx> is at most index of last joint in joint container.
+     * Assumes <diff> contains as many values as joint has parameters.
+     * If values from <diff> added to values of current parameters 
+     * are not bounded by pairs of values in joint limits, 
+     * function does not change the positions
+     * and does not clear component positions 
+     * (configuration is still prepared).
+     * 
+     * \param idx Joint index
+     * @param diff Span of values to be added to current parameters (can be negative).
+     * @return result_error if any of the resulting parameters 
+     * does not respect corresponding joint limit. 
+     */
+    atoms::Result< std::monostate> changeJointPositionsBy( int idx, std::span< float > diff );
 
     /**
      * \brief Get a component position relative to module origin

--- a/softwareComponents/configuration/src/rofiworld.cpp
+++ b/softwareComponents/configuration/src/rofiworld.cpp
@@ -122,6 +122,23 @@ void Module::setJointPositions( int idx, std::span< const float > p ) {
         parent->onModuleMove();
 }
 
+atoms::Result< std::monostate > Module::changeJointPositionsBy( int idx, std::span< float > diff ) {
+    assert( idx >= 0 );
+    assert( to_unsigned( idx ) < _joints.size() );
+    assert( _joints[ to_unsigned( idx ) ].joint->positions().size() == diff.size() );
+
+    auto result = _joints[ to_unsigned( idx ) ].joint->changePositionsBy( diff );
+    // Do not clear component positions if the joint change did not happen
+    if ( !result.has_value() )
+        return result;
+
+    _componentRelativePositions = std::nullopt;
+    if ( parent )
+        parent->onModuleMove();
+
+    return result;
+}
+
 void Module::clearComponentPositions() {
     _componentRelativePositions = std::nullopt;
     if ( parent )

--- a/softwareComponents/configuration/test/joints.cpp
+++ b/softwareComponents/configuration/test/joints.cpp
@@ -50,18 +50,18 @@ TEST_CASE( "Base RotationJoint" ) {
         auto j = RotationJoint( identity, { 1, 0, 0 }, translate( { 42, 42, 42 } ), -90_deg, 90_deg );
         REQUIRE( j.positions().size() == 1 );
         Joint& jj = j;
-        tmp = { ( 180_deg ).rad() };
+        tmp = { ( 90_deg ).rad() };
         jj.setPositions( tmp );
         jj.sourceToDest();
         REQUIRE( j.positions().size() == 1 );
-        CHECK( j.positions()[ 0 ] == ( 180_deg ).rad() );
+        CHECK( j.positions()[ 0 ] == ( 90_deg ).rad() );
     }
 }
 
 TEST_CASE( "sourceToDest and destToSource" ) {
     std::vector< float > tmp{ 0 };
     SECTION( "Unit size" ) {
-        auto j = RotationJoint( { 0, 0, 0 }, { 0, 0, 0 }, { 1, 0, 0 }, { 1, 0, 0 }, -90_deg, 90_deg );
+        auto j = RotationJoint( { 0, 0, 0 }, { 0, 0, 0 }, { 1, 0, 0 }, { 1, 0, 0 }, -360_deg, 360_deg );
         j.setPositions( tmp );
         CHECK( equals( j.sourceToDest(), translate( {  1, 0, 0 } ) ) );
         CHECK( equals( j.destToSource(), translate( { -1, 0, 0 } ) ) );
@@ -76,7 +76,7 @@ TEST_CASE( "sourceToDest and destToSource" ) {
     }
 
     SECTION( "Bigger size" ) {
-        auto j = RotationJoint( { 0, 0, 0 }, { 0, 0, 0 }, { 5, 0, 0 }, { 0, 1, 0 }, -90_deg, 90_deg );
+        auto j = RotationJoint( { 0, 0, 0 }, { 0, 0, 0 }, { 5, 0, 0 }, { 0, 1, 0 }, -180_deg, 180_deg );
         j.setPositions( tmp );
         CHECK( equals( j.sourceToDest(), translate( { 5, 0, 0 } ) ) );
         tmp = { ( 180_deg ).rad() };

--- a/softwareComponents/configuration/test/serialization.cpp
+++ b/softwareComponents/configuration/test/serialization.cpp
@@ -120,11 +120,11 @@ TEST_CASE( "UniversalModule" ) {
         CHECK( js[ "modules" ][ 0 ][ "gamma" ] == 180 );
     }
 
-    SECTION( "Signle With rotational joint" ) {
+    SECTION( "Single With rotational joint" ) {
         auto& m1 = world.insert( UniversalModule( idCounter++, 0_deg, 0_deg, 0_rad ) );
         connect< RotationJoint >( m1.bodies()[ 0 ], Vector{ 0, 0, 0 }
                                 , identity, Vector{ 1, 0, 0 }, translate( { 0, 0, 1 } )
-                                , Angle::deg( 90 ), Angle::deg( 90 ) );
+                                , Angle::deg( -90 ), Angle::deg( 90 ) );
     }
 
     SECTION( "Multiple Modules" ) {


### PR DESCRIPTION
First commit: Adds boundary checking for parameters given to setPositions function (boundaries are defined by joint limits), which sets the parameters (rotations and/or other) of a joint; if values are out of bounds, throws logic_error.
Also adds changePositionsBy function, which does not set the parameters to given values, but adds their values to the values given. If the resulting values are out of bounds, does not throw an error, but returns an atoms::result_error, and does not change the current parameters of the joint.

Second commit: Changes tests to reflect the functionality introduced by the first commit.