### PR TITLE
rofiTool: add shape command

### DIFF
--- a/softwareComponents/isoreconfig/include/isoreconfig/geometry.hpp
+++ b/softwareComponents/isoreconfig/include/isoreconfig/geometry.hpp
@@ -6,6 +6,11 @@
 
 namespace rofi::isoreconfig {
 
+/**
+ * @brief Point in space
+ */
+using Vector = arma::vec4;
+
 static constexpr double ERROR_MARGIN = 0.01;
 
 /**
@@ -89,7 +94,7 @@ public:
     /**
      * @brief Cloud points as vector< Vector >.
      */
-    Vector toVectors() const
+    std::vector< Vector > toVectors() const
     {
         std::vector< Vector > vecs( size() );
 

--- a/softwareComponents/isoreconfig/include/isoreconfig/geometry.hpp
+++ b/softwareComponents/isoreconfig/include/isoreconfig/geometry.hpp
@@ -6,103 +6,212 @@
 
 namespace rofi::isoreconfig {
 
-constexpr double ERROR_MARGIN = 1.0 / 1000000;
+static constexpr double ERROR_MARGIN = 0.01;
 
 /**
- * @brief "Point" (three-dimensional vector)
+ * @brief Cloud of Points (CoP) - normalized container of points
+ * (transformed using PCA, rounded to int, sorted).
  */
-using Point = arma::vec3;
-/**
- * @brief Container of points
- */
-using Cloud = std::vector< Point >;
-/**
- * @brief "Position" (4x4 matrix)
- */
-using Matrix = arma::mat44;
-/**
- * @brief Container of positions
- */
-using Positions = std::vector< Matrix >;
-/**
- * @brief Score (<n> x 3 matrix with <n> points as rows)
- */
-using Score = arma::mat;
-
+class Cloud;
 
 /**
- * @brief Converts a point to a position.
+ * @brief Decides whether given clouds define an equal physical shape.
+ * Assumes different number of points in cloud means different shapes.
+ * Attempts to find an orthogonal rotation
+ * which transforms one cloud into the other.
  */
-Matrix pointToPos( const Point& point );
+bool isometric( const Cloud& cop1, Cloud cop2 );
 
-/**
- * @brief Converts a cloud to positions
- */
-Positions cloudToPositions( const Cloud& cop );
+class Cloud
+{
+    using Point = std::array< int, 3 >;
 
-/**
- * @brief Converts a position to a point.
- */
-Point posToPoint( const Matrix& position );
+    std::vector< Point > _points;
+    arma::mat _coeff; // PC coefficients - cols are (base) eigenvectors
 
-/**
- * @brief Converts positions to a cloud.
- */
-Cloud positionsToCloud( const Positions& poss );
+public:
 
-/**
- * @brief Converts cloud to score.
- */
-Score cloudToScore( const Cloud& cop );
+    explicit Cloud( const std::vector< Vector >& pts ) 
+    {
+        arma::mat data;
+        data.set_size( pts.size(), 3 );
 
-/**
- * @brief Converts score to a cloud.
- */
-Cloud scoreToCloud( const Score& score );
+        for ( size_t i = 0; i < pts.size(); ++i )
+            for ( size_t j = 0; j < 3; ++j )
+                data(i, j) = pts[i](j);
 
+        std::tie( data, _coeff ) = normalize( data );
+        auto rawPoints = dataToPoints( data );
+        _points = roundPoints( rawPoints );
+        sortPoints();
+    }
 
-/**
- * @brief Calculate the centroid (unweighted average) 
- * of a given cloud of points.
- * Assumes the cloud is not empty.
- * @param cop Cloud to calculate the centroid from.
- * @return Unweighted average (centroid) of a given <cop>.
- */
-Point centroid( const Cloud& cop );
+    /**
+     * @brief Rotates the points by 90 degrees around given axis.
+     */
+    void rotateBy90Around( size_t axis )
+    {
+        swapAxes( (axis + 1) % 3, (axis + 2) % 3 );
+        negateAxis( (axis + 2) % 3 );
+        sortPoints();
+    }
 
-/**
- * @brief Calculate the centroid (unweighted average) 
- * of given positions.
- * Assumes the vector is not empty.
- * @param positions Vector to calculate the center of gravity from.
- * @return Unweighted average (centroid) of a given vector <positions>.
- */
-Matrix centroid( const Positions& positions );
+    /**
+     * @brief Rotates the points by 180 degrees around given axis.
+     */
+    void rotateBy180Around( size_t axis )
+    {
+        negateAxis( (axis + 1) % 3 );
+        negateAxis( (axis + 2) % 3 );
+        sortPoints();
+    }
 
-/**
- * @brief Finds points furthest and second furthest away from <centerPos> 
- * in <cop>.
- * @param center Point to measure the distance from. 
- * @param cop Cloud of points to go through.
- * @param epsilon Maximum distance two points can be apart to be considered
- * the same point.
- * @return Array of two clouds, first contains points furthest away from 
- * <center>, second contains those second furthest away from <center>. 
- */
-std::array< Cloud, 2 > longestVectors( 
-    const Point& center, const Cloud& cop, 
-    const double epsilon = ERROR_MARGIN );
+    /**
+     * @brief Permutate axes (X -> Y -> Z -> X).
+     */
+    void permutateAxes()
+    {
+        swapAxes( 1, 2 );
+        swapAxes( 0, 1 );
+        sortPoints();
+    }
 
-/**
- * @brief Finds points furthest and second furthest away from the center of
- * gravity of <cop> in <cop>.
- * @param cop Cloud of points to go through.
- * @param epsilon Maximum distance two points can be apart to be considered
- * the same point.
- * @return Array of two clouds, first contains points furthest away from 
- * the center of gravity, second contains those second furthest away from it. 
- */
-std::array< Cloud, 2 > longestVectors( 
-    const Cloud& cop, const double epsilon = ERROR_MARGIN );
+    /**
+     * @brief Returns the PCA transformation used to convert original points
+     * into the points defining the resulting cloud.
+     */
+    arma::mat transformation() const
+    {
+        // transposed _coeff is PCA transformation matrix
+        return _coeff.t();
+    }
+
+    /**
+     * @brief Cloud points as vector< Vector >.
+     */
+    Vector toVectors() const
+    {
+        std::vector< Vector > vecs( size() );
+
+        for ( size_t pt = 0; pt < size(); ++pt )
+            for ( size_t col = 0; col < 3; ++col )
+                vecs[pt](col) = _points[pt][col] * ERROR_MARGIN;
+
+        return vecs;
+    }
+
+    bool operator==( const Cloud& o ) const
+    {
+        return _points == o._points;
+    }
+
+    size_t size() const
+    {
+        return _points.size();
+    }
+
+    auto begin() const
+    {
+        return _points.begin();
+    }
+
+    auto begin()
+    {
+        return _points.begin();
+    }
+
+    auto end() const
+    {
+        return _points.end();
+    }
+
+    auto end()
+    {
+        return _points.end();
+    }
+
+    void print() const
+    {
+        for ( const Point& pt : _points )
+            std::cout << pt[0] << "   " << pt[1] << "   " << pt[2] << "\n";
+    }
+
+private:
+
+    /**
+     * @brief Normalize given points (data) to use their PCA coordinate system
+     * (or its reflection in case the PCA transformation is a reflection,
+     * so the shape given by the points does not change).
+     * Returns normalized data and its transformation matrix.
+     */
+    std::tuple< arma::mat, arma::mat > normalize( const arma::mat& data ) const
+    {
+        arma::mat coeff;
+        arma::mat score;
+        arma::vec latent;
+        arma::vec tsquared;
+
+        princomp( coeff, score, latent, tsquared, data );
+        auto determinant = det( coeff );
+        assert( std::abs( determinant ) - 1 < ERROR_MARGIN );
+
+        // If determinant is negative (therefore ~= -1), reflect along one plane (we use YZ).
+        // (negative sign -> reflection, which can change the shape of the cloud)
+        if ( determinant < 0 )
+        {
+            score.col(0) *= -1;
+            coeff.col(0) *= -1;
+        } 
+
+        return std::tie( score, coeff );
+    }
+
+    std::vector< std::array< double, 3 > > dataToPoints( const arma::mat& data ) const
+    {
+        std::vector< std::array< double, 3 > > points( data.n_rows );
+        
+        for ( size_t pt = 0; pt < data.n_rows; ++pt )
+            for ( size_t col = 0; col < 3; ++col )
+                points[pt][col] = data( pt, col ); 
+    
+        return points;
+    }
+
+    std::vector< Point > roundPoints( 
+        const std::vector< std::array< double, 3 > >& rawPoints ) const
+    {   
+        std::vector< Point > roundedPoints( rawPoints.size() );
+
+        for ( size_t pt = 0; pt < rawPoints.size(); ++pt )
+            for ( size_t col = 0; col < 3; ++col )
+                roundedPoints[pt][col] = static_cast<int>( round( rawPoints[pt][col] / ERROR_MARGIN ) );
+
+        return roundedPoints;
+    }
+
+    void sortPoints()
+    {
+        auto pointComparator = []( const Point& p1, const Point& p2 ) 
+        {
+            return p1[0] < p2[0]
+                || ((p1[0] == p2[0] && p1[1] < p2[1]) 
+                || (p1[0] == p2[0] && p1[1] == p2[1] && p1[2] < p2[2])); 
+        };
+
+        std::ranges::sort( _points, pointComparator );
+    }
+
+    void swapAxes( size_t ax1, size_t ax2 )
+    {
+        for ( Point& pt : _points )
+            std::swap( pt[ax1], pt[ax2] );
+    }
+
+    void negateAxis( size_t ax )
+    {
+        for ( Point& pt : _points )
+            pt[ax] = -pt[ax];
+    }
+};
 
 } // namespace rofi::isoreconfig

--- a/softwareComponents/isoreconfig/include/isoreconfig/isomorphic.hpp
+++ b/softwareComponents/isoreconfig/include/isoreconfig/isomorphic.hpp
@@ -1,4 +1,5 @@
 #include <configuration/rofiworld.hpp>
+#include <isoreconfig/geometry.hpp>
 
 namespace rofi::isoreconfig {
 
@@ -34,13 +35,25 @@ Positions decomposeUniversalModule( const rofi::configuration::Module& mod );
 std::array< Positions, 2 > decomposeRofiWorld( const rofi::configuration::RofiWorld& rw );
 
 /**
- * @brief Calculate the center of gravity (unweighted average of module-defining
- * points) from a given RofiWorld <rw>.
+ * @brief Converts a RofiWorld to a Cloud of Points.
+ */
+Cloud rofiWorldToCloud( const rofi::configuration::RofiWorld& rw );
+
+/**
+ * @brief Calculate the centroid from a given RofiWorld <rw>.
  * Raises std::logic_error if the RofiWorld <rw> has not been prepared.
  * @param rb RofiWorld to calculate the center of gravity from.
  * @return Unweighted average of points defining the RofiWorld
  * (module points, not connection points).
  */
 Matrix centroid( const rofi::configuration::RofiWorld& rw );
+
+/**
+ * @brief Decides if given rofiworlds have the same physical shape.
+ * Decomposes the worlds into points, applies PCA transformation 
+ * and attempts to find an orthogonal transformation
+ * which transforms one set of points into the other.
+ */
+bool equalShape( const rofi::configuration::RofiWorld& rw1, const rofi::configuration::RofiWorld& rw2 );
 
 } // namespace rofi::isoreconfig

--- a/softwareComponents/isoreconfig/include/isoreconfig/isomorphic.hpp
+++ b/softwareComponents/isoreconfig/include/isoreconfig/isomorphic.hpp
@@ -3,13 +3,15 @@
 
 namespace rofi::isoreconfig {
 
+using namespace rofi::configuration;
+
 /**
  * @brief Position matrix
  */
 using Matrix = arma::mat44;
 
 /**
- * @brief Extends a point to a matrix.
+ * @brief Extends Vector to a matrix.
  */
 Matrix pointMatrix( const Vector& pt );
 
@@ -18,10 +20,10 @@ Matrix pointMatrix( const Vector& pt );
  * each in the center of one of the RoFIComs.
  * Assumes the RofiWorld the module belongs to has been prepared, 
  * so the RoFIComs have a relative position in space.
- * @param rModule Module from which the points are calculated.
+ * @param mod Module from which the points are calculated.
  * @return Container of points, each in the center of a corresponding RoFICom.
  */
-std::vector< Vector > decomposeModule( const rofi::configuration::Module& rModule );
+std::vector< Vector > decomposeModule( const Module& mod );
 
 /**
  * @brief Decomposes given RofiWorld <rw> into two containers of points;
@@ -32,13 +34,23 @@ std::vector< Vector > decomposeModule( const rofi::configuration::Module& rModul
  * @param rw RofiWorld from which the points are calculated.
  * @return First container contains RoFICom points, second contains connection points.
  */
-std::tuple< std::vector< Vector >, std::vector< Vector > > decomposeRofiWorld( 
-    const rofi::configuration::RofiWorld& rw );
+std::tuple< std::vector< Vector >, std::vector< Vector > > 
+    decomposeRofiWorld( const RofiWorld& rw );
+
+std::vector< std::vector< Vector > > decomposeRofiWorldModules( const RofiWorld& rw );
 
 /**
  * @brief Converts a RofiWorld to a Cloud of Points.
  */
-Cloud rofiWorldToCloud( const rofi::configuration::RofiWorld& rw );
+Cloud rofiWorldToCloud( const RofiWorld& rw );
+
+/**
+ * @brief Converts a RofiWorld to a canonical cloud of points,
+ * which uniquely defines its shape.
+ */
+Cloud rofiWorldToShape( const RofiWorld& rw );
+
+std::array< int, 4 > rofiWorldToEigenValues( const RofiWorld& rw );
 
 /**
  * @brief Calculate the centroid from a given RofiWorld <rw>.
@@ -46,15 +58,7 @@ Cloud rofiWorldToCloud( const rofi::configuration::RofiWorld& rw );
  * @param rw RofiWorld to calculate the centroid from.
  * @return Unweighted average of points defining the RofiWorld.
  */
-Vector centroid( const rofi::configuration::RofiWorld& rw );
-
-/**
- * @brief Calculate the centroid (unweighted average) of given points.
- * Assumes the container is not empty.
- * @param pts Points to calculate the center of gravity from.
- * @return Centroid of given points.
- */
-Vector centroid( const std::vector< Vector >& pts );
+Vector centroid( const RofiWorld& rw );
 
 /**
  * @brief Decides if given rofiworlds have the same physical shape.
@@ -62,8 +66,6 @@ Vector centroid( const std::vector< Vector >& pts );
  * and attempts to find an orthogonal transformation
  * which transforms one set of points into the other.
  */
-bool equalShape( 
-    const rofi::configuration::RofiWorld& rw1, 
-    const rofi::configuration::RofiWorld& rw2 );
+bool equalShape( const RofiWorld& rw1, const RofiWorld& rw2 );
 
 } // namespace rofi::isoreconfig

--- a/softwareComponents/isoreconfig/include/isoreconfig/isomorphic.hpp
+++ b/softwareComponents/isoreconfig/include/isoreconfig/isomorphic.hpp
@@ -4,7 +4,7 @@
 namespace rofi::isoreconfig {
 
 /**
- * @brief "Position" (4x4 matrix)
+ * @brief Position matrix
  */
 using Matrix = arma::mat44;
 /**

--- a/softwareComponents/isoreconfig/include/isoreconfig/isomorphic.hpp
+++ b/softwareComponents/isoreconfig/include/isoreconfig/isomorphic.hpp
@@ -7,32 +7,33 @@ namespace rofi::isoreconfig {
  * @brief Position matrix
  */
 using Matrix = arma::mat44;
+
 /**
- * @brief Container of positions
+ * @brief Extends a point to a matrix.
  */
-using Positions = std::vector< Matrix >;
-
+Matrix pointMatrix( const Vector& pt );
 
 /**
- * @brief Creates a vector of positions from a given module <mod> by splitting it
- * into six distinct points, each in the center of one of the RoFIComs.
- * Assumes the module is a UniversalModule.
- * Assumes the RofiWorld the module belongs to has been prepared, so the RoFIComs 
- * have a relative position.
- * @param mod Module from which the points are calculated.
- * @return Vector of six point matrices, each in the center of a corresponding RoFICom. 
+ * @brief Decomposes given module <mod> into distinct points, 
+ * each in the center of one of the RoFIComs.
+ * Assumes the RofiWorld the module belongs to has been prepared, 
+ * so the RoFIComs have a relative position in space.
+ * @param rModule Module from which the points are calculated.
+ * @return Container of points, each in the center of a corresponding RoFICom.
  */
-Positions decomposeUniversalModule( const rofi::configuration::Module& mod );
+std::vector< Vector > decomposeModule( const rofi::configuration::Module& rModule );
 
 /**
- * @brief Creates a vector of positions from a given RofiWorld <rw> by splitting 
- * every module into six distinct points, each in the center of one of the RoFIComs.
- * Assumes the RofiWorld consists only of UniversalModules.
+ * @brief Decomposes given RofiWorld <rw> into two containers of points;
+ * first container contains points aquired by decomposing each module
+ * (a point in the center of every RoFICom),
+ * second container contains points in the centres of connected RoFIComs.
  * Assumes the RofiWorld has been prepared, so the modules have a relative position.
- * @param rb RofiWorld from which the points are calculated.
- * @return Vector of point matrices, each in the center of a corresponding RoFICom. 
+ * @param rw RofiWorld from which the points are calculated.
+ * @return First container contains RoFICom points, second contains connection points.
  */
-std::array< Positions, 2 > decomposeRofiWorld( const rofi::configuration::RofiWorld& rw );
+std::tuple< std::vector< Vector >, std::vector< Vector > > decomposeRofiWorld( 
+    const rofi::configuration::RofiWorld& rw );
 
 /**
  * @brief Converts a RofiWorld to a Cloud of Points.
@@ -42,11 +43,18 @@ Cloud rofiWorldToCloud( const rofi::configuration::RofiWorld& rw );
 /**
  * @brief Calculate the centroid from a given RofiWorld <rw>.
  * Raises std::logic_error if the RofiWorld <rw> has not been prepared.
- * @param rb RofiWorld to calculate the center of gravity from.
- * @return Unweighted average of points defining the RofiWorld
- * (module points, not connection points).
+ * @param rw RofiWorld to calculate the centroid from.
+ * @return Unweighted average of points defining the RofiWorld.
  */
-Matrix centroid( const rofi::configuration::RofiWorld& rw );
+Vector centroid( const rofi::configuration::RofiWorld& rw );
+
+/**
+ * @brief Calculate the centroid (unweighted average) of given points.
+ * Assumes the container is not empty.
+ * @param pts Points to calculate the center of gravity from.
+ * @return Centroid of given points.
+ */
+Vector centroid( const std::vector< Vector >& pts );
 
 /**
  * @brief Decides if given rofiworlds have the same physical shape.
@@ -54,6 +62,8 @@ Matrix centroid( const rofi::configuration::RofiWorld& rw );
  * and attempts to find an orthogonal transformation
  * which transforms one set of points into the other.
  */
-bool equalShape( const rofi::configuration::RofiWorld& rw1, const rofi::configuration::RofiWorld& rw2 );
+bool equalShape( 
+    const rofi::configuration::RofiWorld& rw1, 
+    const rofi::configuration::RofiWorld& rw2 );
 
 } // namespace rofi::isoreconfig

--- a/softwareComponents/isoreconfig/src/geometry.cpp
+++ b/softwareComponents/isoreconfig/src/geometry.cpp
@@ -2,119 +2,32 @@
 
 namespace rofi::isoreconfig {
 
-Matrix pointToPos( const Point& point )
+bool isometric( const Cloud& cop1, Cloud cop2 )
 {
-    Matrix result( arma::fill::eye );
-    for ( int i = 0; i < 3; ++i )
-        result(i,3) = point(i);
-    return result;
-}
+    // Assume different number of points implies nonequal shapes
+    // (even if points overlap)
+    if ( cop1.size() != cop2.size() )
+        return false;
 
-Positions cloudToPositions( const Cloud& cop )
-{
-    Positions result;
-    for ( const Point& p : cop ) 
-        result.push_back( pointToPos( p ) );
-    return result;
-}
-
-Point posToPoint( const Matrix& position )
-{
-    return Point{ position.at(0,3), position.at(1,3), position.at(2,3) };
-}
-
-Cloud positionsToCloud( const Positions& poss )
-{
-    Cloud result;
-    for ( const Matrix& pos : poss ) 
-        result.push_back( posToPoint( pos ) );
-    return result;
-}
-
-Score cloudToScore( const Cloud& cop )
-{
-    arma::mat result( cop.size(), 3 );
-
-    for ( size_t i = 0; i < cop.size(); ++i )  
-        for ( size_t j = 0; j < 3; ++j )
-            result(i, j) = cop[i](j);
-
-    return result;
-}
-
-Cloud scoreToCloud( const Score& score )
-{
-    Cloud result;
-
-    for ( size_t i = 0; i < score.n_rows; ++i )
-        result.push_back( { score(i,0), score(i, 1), score(i, 2) } );
-
-    return result;
-}
-
-
-Point centroid( const Cloud& cop )
-{
-    assert( cop.size() >= 1 );
-    Point result = { 0, 0, 0 };
-    
-    for ( const Point& point : cop )
-        result += point;
-
-    double pointCount = double(cop.size());
-    return result / Point( { pointCount, pointCount, pointCount } );
-}
-
-Matrix centroid( const Positions& positions )
-{
-    Cloud cop;
-    for ( const Matrix& pos : positions )
-        cop.push_back( posToPoint( pos ) );
-
-    return pointToPos( centroid( cop ) );
-}
-
-double cubeNorm( const Point& vec )
-{
-    return vec( 0 ) * vec( 0 ) + vec( 1 ) * vec( 1 ) + vec( 2 ) * vec( 2 );
-} 
-
-std::array< Cloud, 2 > longestVectors( const Point& center, const Cloud& cop, const double epsilon )
-{
-    std::array< Cloud, 2 > result{ std::vector{center} };
-    double longestNorm = 0;
-    double sndLongestNorm = 0;
-
-    for ( const Point& currPoint : cop )
+    // Go through 24 orthogonal rotations in third dimension
+    // (8 octants, each of which can have the axes arranged in 3 ways)
+    for ( size_t hp = 0; hp < 2; ++hp ) 
     {
-        double nextNorm = cubeNorm( currPoint - center );
-
-        if ( nextNorm - longestNorm > epsilon )
+        for ( size_t rot = 0; rot < 4; ++rot ) 
         {
-            // New longest vector, shift old longest to second longest
-            result[1] = std::exchange( result[0], { currPoint } );
-            sndLongestNorm = std::exchange( longestNorm, nextNorm );
+            for ( size_t permut = 0; permut < 3; ++permut )  
+            {
+                if ( cop1 == cop2 ) 
+                    return true;
+                
+                cop2.permutateAxes(); // Permute axes in current octant
+            }
+            cop2.rotateBy90Around( 0 ); // Rotating Y and Z around X
         }
-        else if ( std::abs( nextNorm - longestNorm ) <= epsilon )
-            // Another longest vector
-            result[0].push_back( currPoint );
-        else if ( nextNorm - sndLongestNorm > epsilon )
-        {
-            // New second longest vector
-            result[1] = { currPoint };  
-            sndLongestNorm = nextNorm;
-        }
-        else if ( std::abs( nextNorm - sndLongestNorm ) <= epsilon )
-            // Another second longest vector
-            result[1].push_back( currPoint );         
+        cop2.rotateBy180Around( 2 ); // Rotate X upside down along Z
     }
-
-    return result;
-}
-
-std::array< Cloud, 2 > longestVectors( const Cloud& cop, const double eps )
-{
-    return longestVectors( centroid( cop ), cop, eps );
+    
+    return false;
 }
 
 } // namespace rofi::isoreconfig

--- a/softwareComponents/isoreconfig/src/geometry.cpp
+++ b/softwareComponents/isoreconfig/src/geometry.cpp
@@ -2,6 +2,19 @@
 
 namespace rofi::isoreconfig {
 
+Vector centroid( const std::vector< Vector >& pts )
+{
+    assert( pts.size() >= 1 );
+
+    Vector result = std::accumulate( ++pts.begin(), pts.end(), pts[0], 
+        []( const Vector& pt1, const Vector& pt2 ){ return pt1 + pt2; } );
+
+    for ( size_t i = 0; i < 3; ++i )
+        result(i) /= double(pts.size());
+
+    return result;
+}
+
 bool isometric( const Cloud& cop1, Cloud cop2 )
 {
     // Assume different number of points implies nonequal shapes
@@ -24,10 +37,32 @@ bool isometric( const Cloud& cop1, Cloud cop2 )
             }
             cop2.rotateBy90Around( 0 ); // Rotating Y and Z around X
         }
-        cop2.rotateBy180Around( 2 ); // Rotate X upside down along Z
+        cop2.rotateBy180Around( 2 ); // Rotate X upside down along Z (bottom octants)
     }
     
     return false;
+}
+
+Cloud canonCloud( Cloud cop )
+{
+    Cloud res = cop;
+
+    for ( size_t hp = 0; hp < 2; ++hp ) 
+    {
+        for ( size_t rot = 0; rot < 4; ++rot ) 
+        {
+            for ( size_t permut = 0; permut < 3; ++permut )  
+            {
+                res = std::max( res, cop );
+                
+                cop.permutateAxes(); // Permute axes in current octant
+            }
+            cop.rotateBy90Around( 0 ); // Rotating Y and Z around X
+        }
+        cop.rotateBy180Around( 2 ); // Rotate X upside down along Z (bottom octants)
+    }
+
+    return res;
 }
 
 } // namespace rofi::isoreconfig

--- a/tools/rofiTool/CMakeLists.txt
+++ b/tools/rofiTool/CMakeLists.txt
@@ -17,6 +17,7 @@ set(ROFI_TOOL_SRCS
     module_count.cpp
     points.cpp
     preview.cpp
+    shape.cpp
 )
 
 add_executable(rofi-tool ${ROFI_TOOL_SRCS} ${MODEL_RESOURCES})

--- a/tools/rofiTool/rendering.cpp
+++ b/tools/rofiTool/rendering.cpp
@@ -3,7 +3,6 @@
 #include <string_view>
 
 #include <atoms/resources.hpp>
-#include <isoreconfig/geometry.hpp>
 #include <isoreconfig/isomorphic.hpp>
 
 #include <vtkActor.h>
@@ -399,64 +398,39 @@ void buildRofiWorldPointsScene( vtkRenderer & renderer, RofiWorld world, bool sh
     using namespace rofi::isoreconfig;
 
     world.validate().get_or_throw_as< std::logic_error >();
-    std::array< Positions, 2 > pts = decomposeRofiWorld( world );
+    auto [ modulePoints, connectionPoints ] = decomposeRofiWorld( world );
 
-    // merge [0] module points and [1] connection points
-    for ( const Matrix & pos : pts[ 1 ] ) {
-        pts[ 0 ].push_back( pos );
-    }
+    // merge module points and connection points
+    for ( const Vector& pt : connectionPoints )
+        modulePoints.push_back( pt );
 
-    arma::mat coeff;    // principal component coefficients
-    arma::mat score;    // projected data - points in new coordinate system
-    arma::vec latent;   // eigenvalues of the covariance matrix of X - eigenvectors for PCA space
-    arma::vec tsquared; // Hotteling's statistic for each sample
-    princomp( coeff, score, latent, tsquared, cloudToScore( positionsToCloud( pts[ 0 ] ) ) );
+    // Transform all points to PCA coordinate system
+    Cloud cop( modulePoints );
+    std::vector< Vector > newPts = cop.toVectors();
 
-    auto determinant = det( coeff );
-    assert( std::abs( std::abs( determinant ) - 1 ) < ERROR_MARGIN );
-    // If transformation is a reflection, reflect back along YZ plane
-    // (otherwise there are rendering issues with modules)
-    if ( determinant < 0 ) {
-        score *= arma::mat{ { -1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } };
-        coeff *= arma::mat{ { -1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } };
-    }
+    // Show points (colour depends on index)
+    for ( size_t pt = 0; pt < newPts.size(); ++pt )
+        addPointToScene( renderer, pointMatrix( newPts[pt] ), getModuleColor( int(pt) ) );
 
-    Positions pos = cloudToPositions( scoreToCloud( score ) );
-    assert( pos.size() == pts[ 0 ].size() );
+    // Show centroid (black) - PCA shifts centroid to (0, 0, 0)
+    addPointToScene( renderer, arma::eye( 4, 4 ), { 0, 0, 0 } );
 
-    // Show module points (colour depends on index)
-    assert( pts[ 0 ].size() >= pts[ 1 ].size() );
-    for ( size_t i = 0; i < pts[ 0 ].size() - pts[ 1 ].size(); ++i ) {
-        addPointToScene( renderer, pos[ i ], getModuleColor( int( i ) ) );
-    }
+    if ( !showModules ) return;
+    
+    // Get and extend transformation to 4x4 matrix
+    arma::mat transf = cop.transformation();
+    transf.resize( 4, 4 );
+    transf.row(3).zeros();
+    transf.col(3).zeros();
+    transf(3, 3) = 1;
 
-    // Show connector points (green)
-    for ( size_t i = pts[ 0 ].size() - pts[ 1 ].size(); i < pos.size(); ++i ) {
-        addPointToScene( renderer, pos[ i ], { 0, 1, 0 }, 1 / 90.0 );
-    }
-
-    // Show centroid (black)
-    addPointToScene( renderer, centroid( pos ), { 0, 0, 0 } );
-
-    if ( !showModules )
-        return;
-
-    // Transpose and extend <coeff> to 4x4 matrix
-    // (transposed <coeff> is PCA transformation)
-    Matrix transf = arma::eye( 4, 4 );
-    for ( int i = 0; i < 3; ++i ) {
-        for ( int j = 0; j < 3; ++j ) {
-            transf( i, j ) = coeff( j, i );
-        }
-    }
-
-    // Translate reference points by the initial centroid in the direction of transf
-    Matrix translation = matrices::translate( transf * ( -centroid( pts[ 0 ] ).col( 3 ) ) );
-
-    // Transform rofi world reference points to new PCA coordinate system
-    for ( auto j = world.referencePoints().begin(); j != world.referencePoints().end(); ++j ) {
-        Vector newRefPoint = translation * j->refPoint;
-
+    Vector oldCentroid = centroid( modulePoints );
+    // Transform configuration reference points to new PCA coordinate system
+    for ( auto j = world.referencePoints().begin(); j != world.referencePoints().end(); ++j )
+    {
+        Vector newRefPoint = transf * ( j->refPoint - oldCentroid );
+        newRefPoint(3) = 0;
+        
         // Affix new reference point in new coordinate system <transf>
         const Component & comp = world.getModule( j->destModule )->components()[ j->destComponent ];
         world.disconnect( j.get_handle() );

--- a/tools/rofiTool/shape.cpp
+++ b/tools/rofiTool/shape.cpp
@@ -1,0 +1,73 @@
+#include <atoms/cmdline_utils.hpp>
+#include <configuration/rofiworld.hpp>
+#include <isoreconfig/isomorphic.hpp>
+#include <dimcli/cli.h>
+#include <parsing/parsing.hpp>
+
+void shape( Dim::Cli & cli );
+
+static auto command = Dim::Cli()
+    .command( "shape" )
+    .action( shape )
+    .desc( "Compare the shapes of two given configurations" );
+static auto & firstInputWorldFile = command.opt< std::filesystem::path >( "<first_input_world_file>" )
+    .defaultDesc( {} )
+    .desc( "First input world file ('-' for standard input)" );
+static auto & firstWorldFormat = command.opt< rofi::parsing::RofiWorldFormat >( "f firstFormat" )
+    .valueDesc( "first_world_format" )
+    .desc( "Format of the first world file" )
+    .choice( rofi::parsing::RofiWorldFormat::Json, "json" )
+    .choice( rofi::parsing::RofiWorldFormat::Voxel, "voxel" )
+    .choice( rofi::parsing::RofiWorldFormat::Old, "old" );
+static auto & secondInputWorldFile = command.opt< std::filesystem::path >( "<second_input_world_file>" )
+    .defaultDesc( {} )
+    .desc( "Second input world file ('-' for standard input)" );
+static auto & secondWorldFormat = command.opt< rofi::parsing::RofiWorldFormat >( "s secondFormat" )
+    .valueDesc( "second_world_format" )
+    .desc( "Format of the second world file" )
+    .choice( rofi::parsing::RofiWorldFormat::Json, "json" )
+    .choice( rofi::parsing::RofiWorldFormat::Voxel, "voxel" )
+    .choice( rofi::parsing::RofiWorldFormat::Old, "old" );
+
+void shape( Dim::Cli & cli ) 
+{
+    auto firstWorld = atoms::readInput( *firstInputWorldFile, [ & ]( std::istream & istr ) {
+        return rofi::parsing::parseRofiWorld( istr, *firstWorldFormat );
+    } );
+    if ( !firstWorld ) {
+        cli.fail( EXIT_FAILURE, "Error while parsing first world", firstWorld.assume_error() );
+        return;
+    }
+
+    auto secondWorld = atoms::readInput( *secondInputWorldFile, [ & ]( std::istream & istr ) {
+        return rofi::parsing::parseRofiWorld( istr, *secondWorldFormat );
+    } );
+    if ( !secondWorld ) {
+        cli.fail( EXIT_FAILURE, "Error while parsing second world", secondWorld.assume_error() );
+        return;
+    }
+
+    // If either world is empty, they have equal shape iff both of them
+    // are empty (sum of the number of their modules is 0).
+    if ( firstWorld->modules().empty() || secondWorld->modules().empty() )
+        exit( int( firstWorld->modules().size() + secondWorld->modules().size() ) );
+
+    if ( firstWorld->referencePoints().empty() )
+        rofi::parsing::fixateRofiWorld( *firstWorld );
+    if ( secondWorld->referencePoints().empty() )
+        rofi::parsing::fixateRofiWorld( *secondWorld );
+
+    if ( auto valid = firstWorld->validate(); !valid ) {
+        cli.fail( EXIT_FAILURE, "First rofi world is invalid", valid.assume_error() );
+        return;
+    }
+    if ( auto valid = secondWorld->validate(); !valid ) {
+        cli.fail( EXIT_FAILURE, "Second rofi world is invalid", valid.assume_error() );
+        return;
+    }
+
+    if ( !rofi::isoreconfig::equalShape( *firstWorld, *secondWorld ) ) {
+        exit( EXIT_FAILURE ); // Avoid dimcli error message
+    }
+}
+


### PR DESCRIPTION
Adds "shape" command to rofi-tool, which takes two RofiWorlds and decides whether their physical shape (defined using standard module decomposition - a point for each RoFICom and each connection) is equal or not .