### PR TITLE
Fix recent CI problems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         environment: [Debug, Release]
-        image: [yaqwsx/rofi.debian, yaqwsx/rofi.ubuntu]
+        image: [ghcr.io/paradise-fi/rofi.debian, ghcr.io/paradise-fi/rofi.ubuntu]
     defaults:
       run:
         shell: bash
@@ -36,7 +36,7 @@ jobs:
       matrix:
         environment: [Debug, Release]
     container:
-      image: yaqwsx/rofi.debian
+      image: ghcr.io/paradise-fi/rofi.debian
     defaults:
       run:
         shell: bash
@@ -63,7 +63,7 @@ jobs:
       matrix:
         environment: [Debug, Release]
     container:
-      image: yaqwsx/rofi.debian
+      image: ghcr.io/paradise-fi/rofi.debian
     defaults:
       run:
         shell: bash
@@ -81,7 +81,7 @@ jobs:
     name: "Build documentation"
     runs-on: ubuntu-20.04
     container:
-      image: yaqwsx/rofi.doc
+      image: ghcr.io/paradise-fi/rofi.doc
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,9 @@ jobs:
       run:
         shell: bash
     steps:
+      # Work-around for https://github.com/actions/runner-images/issues/6775
+      - name: Change Owner of Container Working Directory
+        run: chown root:root .
       - name: Checkout
         uses: actions/checkout@v2
       - name: "Build"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       image: ${{ matrix.image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         run: |
           source setup.sh ${{ matrix.environment }}
@@ -42,7 +42,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         run: |
           source setup.sh -i ${{ matrix.environment }}
@@ -69,7 +69,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         run: |
           source setup.sh ${{ matrix.environment }}
@@ -90,7 +90,7 @@ jobs:
       - name: Change Owner of Container Working Directory
         run: chown root:root .
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Build"
         run: |
           source setup.sh Debug
@@ -112,7 +112,7 @@ jobs:
 
           releng/doc/buildAllBranches.sh
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: documentation
           path: build.Debug/doc/web
@@ -124,15 +124,15 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout # Required for GH-pages deployment
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Download web"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: documentation
           path: documentation
       - run: ls documentation
       - name: Deploy to GH Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.0
+        uses: JamesIves/github-pages-deploy-action@4.4.1
         with:
           branch: gh-pages
           folder: documentation

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,22 +1,27 @@
-RoFI - Technical Documentation
+RoFI — Technical Documentation
 ==============================
 
 This document provides the technical documentation for the `RoFI Platform
 <https://ro.fi.muni.cz>`_. Start by selecting the topic:
 
+.. table::
+   :widths: 33 33 33
 
-===================  ===================  ===================
-|Getting Started|_                        |RoFI HAL|_
--------------------  -------------------  -------------------
-`Getting Started`_                        `RoFI HAL`_
--------------------  -------------------  -------------------
-|RoFI Library|_      |RoFICoM|_           |Universal Module|_
--------------------  -------------------  -------------------
-`RoFI Library`_      `RoFICoM`_           `Universal Module`_
-===================  ===================  ===================
+   ===================  =======================  ===================
+   |Getting Started|_   |Release engineering|_   |RoFI HAL|_
+   -------------------  -----------------------  -------------------
+   `Getting Started`_   `Release engineering`_   `RoFI HAL`_
+   -------------------  -----------------------  -------------------
+   |RoFI Library|_      |RoFICoM|_               |Universal Module|_
+   -------------------  -----------------------  -------------------
+   `RoFI Library`_      `RoFICoM`_               `Universal Module`_
+   ===================  =======================  ===================
 
 .. |Getting Started| image:: _static/code.jpg
 .. _Getting Started: intro/
+
+.. |Release engineering| image:: _static/code.jpg
+.. _Release engineering: releng/
 
 .. |RoFI HAL| image:: _static/code.jpg
 .. _RoFI HAL: rofihal/
@@ -38,6 +43,7 @@ Note that you can preview the development version of the documentation on
    :caption: Contents:
 
    intro/index
+   releng/index
    tutorials/index
    rofihal/index
    rofilib/index

--- a/doc/releng/index.rst
+++ b/doc/releng/index.rst
@@ -1,0 +1,37 @@
+Release engineering notes
+=========================
+
+This document describes several important notes about release engineering of
+RoFI.
+
+Continuous integration
+----------------------
+
+The projects uses GitHub actions as CI backend. The build process is described
+by the file ``.github/workflows/build.yml``. The build tries to build every
+suite and if present, run suite tests.
+
+To save building and pulling build dependencies every time, the individual
+stages run in Docker container. The images are hosted by ``gcr.io`` and every
+member of the organization `paradise-fi <https://github.com/paradise-fi>`_ can
+access it. Note that you need to invoke ``docker login`` to get access to
+``gcr.io``. You can read more in `GitHub
+documentation <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry>`_.
+
+The images are defined by the files ``Dockerfile`` and ``Dockerfile.doc``. The
+images are shared across all branches (in order to save space). The images can
+also be automatically updated via invoking ``releng/tools/updateDockerImages``.
+
+Documentation
+-------------
+
+This documentation is build under the suite doc. The build process is driven by
+the suite. Under the hood it uses Doxygen and Spinx.
+
+In order to build per-branch documentation (available under
+``https://paradise-fi.github.io/RoFI/branch/<git_branch_name>``) the master
+branch has an extra build step which checks out all branches pushed to origin
+and builds them. For security reasons, builds cannot trigger other builds,
+therefore the master branch is built every night in order to ensure the
+documentation is up-to-date.
+

--- a/releng/tools/updateDockerImages
+++ b/releng/tools/updateDockerImages
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-docker build -t yaqwsx/rofi.debian .
-docker build -t yaqwsx/rofi .
-docker build -t yaqwsx/rofi.ubuntu --build-arg BASE=ubuntu:21.10 .
+docker build -t ghcr.io/paradise-fi/rofi.debian .
+docker build -t ghcr.io/paradise-fi/rofi .
+docker build -t ghcr.io/paradise-fi/rofi.ubuntu --build-arg BASE=ubuntu:22.04 .
+docker build -t ghcr.io/paradise-fi/rofi.doc -f Dockerfile.doc .
 
-docker push yaqwsx/rofi
-docker push yaqwsx/rofi.debian
-docker push yaqwsx/rofi.ubuntu
+docker push ghcr.io/paradise-fi/rofi
+docker push ghcr.io/paradise-fi/rofi.debian
+docker push ghcr.io/paradise-fi/rofi.ubuntu
+docker push ghcr.io/paradise-fi/rofi.doc


### PR DESCRIPTION
This PR addresses two problems:
- there has been a problem with incorrect working directory permission in GH runners. It wasn't noticeable until Git fixed a security bug (https://github.com/actions/runner-images/issues/6775)
- the checkout and other actions use Node JS. The versions were bumped, as Node 14 was deprecated in GH actions.