### PR TITLE
Fix configuration validity check using SimpleCollision

### DIFF
--- a/softwareComponents/configuration/include/configuration/rofiworld.hpp
+++ b/softwareComponents/configuration/include/configuration/rofiworld.hpp
@@ -443,11 +443,12 @@ public:
      * \brief Decide if two modules collide
      */
     bool operator()( const Module& a, const Module& b, Matrix posA, Matrix posB ) {
+        using namespace rofi::configuration::matrices;
+
         for ( auto pA : a.getOccupiedRelativePositions() ) {
             for ( auto pB : b.getOccupiedRelativePositions() ) {
-                if ( rofi::configuration::matrices::equals( static_cast< Matrix >( posA * pA ), posB * pB ) ) {
+                if ( distance( center( posA * pA ), center( posB * pB ) ) < 1 )
                     return true;
-                }
             }
         }
 
@@ -662,7 +663,7 @@ public:
         for ( const ModuleInfo& m : _modules ) {
             for ( const ModuleInfo& n : _modules ) {
                 if ( n.module->_id >= m.module->_id ) // Collision is symmetric
-                    break;
+                    continue;
                 if ( collisionModel( *n.module, *m.module, *n.absPosition, *m.absPosition ) ) {
                     return atoms::result_error( fmt::format( "Modules {} and {} collide",
                         m.module->_id, n.module->_id ) );


### PR DESCRIPTION
Does not assume modules are sorted by their ID.
SimpleCollision now checks if positions occupied by modules are within distance of 1, instead of checking if the positions are the same (does not matter for 90 degrees of rotation, but rofiworld below is valid according to the old check).
 
 RofiWorld that was valid before fix:
 C
M 2 90 0 180
M 1 90 45 0
M 0 90 90 0
E 1 A -Z S -Z A 2
E 0 A -Z S -Z B 1

![image](https://user-images.githubusercontent.com/56394435/220146666-02cb3b58-b070-4b2e-a7d7-1df8e06caf6e.png)
