### PR TITLE
Add hal::delay function, implement delay/wait for esp32

### DIFF
--- a/examples/simulator/basicJointForce/basicJointForce.cpp
+++ b/examples/simulator/basicJointForce/basicJointForce.cpp
@@ -19,11 +19,11 @@ int main()
         auto endCycleFuture = endCyclePromise.get_future();
 
         localRofi.getJoint( 2 ).setTorque( torque );
-        RoFI::wait( 1000, [ & ] {
+        RoFI::postpone( 1000, [ & ] {
             localRofi.getJoint( 2 ).setTorque( -torque );
-            RoFI::wait( 1000, [ & ] {
+            RoFI::postpone( 1000, [ & ] {
                 localRofi.getJoint( 2 ).setTorque( 0 );
-                RoFI::wait( 1000, [ & ] { endCyclePromise.set_value(); } );
+                RoFI::postpone( 1000, [ & ] { endCyclePromise.set_value(); } );
             } );
         } );
 

--- a/examples/simulator/basicJointPosition/basicJointPosition.cpp
+++ b/examples/simulator/basicJointPosition/basicJointPosition.cpp
@@ -30,17 +30,17 @@ int main()
         auto endCycleFuture = endCyclePromise.get_future();
 
         joint.setPosition( 0, speed, [ & ]( Joint ) {
-            RoFI::wait( delayMs, [ & ] {
+            RoFI::postpone( delayMs, [ & ] {
                 joint.setPosition( minPos / 2, speed, [ & ]( Joint ) {
-                    RoFI::wait( delayMs, [ & ] {
+                    RoFI::postpone( delayMs, [ & ] {
                         joint.setPosition( minPos * 9.f / 10, speed, [ & ]( Joint ) {
-                            RoFI::wait( delayMs, [ & ] {
+                            RoFI::postpone( delayMs, [ & ] {
                                 joint.setPosition( maxPos / 2, speed, [ & ]( Joint ) {
-                                    RoFI::wait( delayMs, [ & ] {
+                                    RoFI::postpone( delayMs, [ & ] {
                                         joint.setPosition( maxPos * 9.f / 10,
                                                            speed,
                                                            [ & ]( Joint ) {
-                                                               RoFI::wait( delayMs, [ & ] {
+                                                               RoFI::postpone( delayMs, [ & ] {
                                                                    endCyclePromise.set_value();
                                                                } );
                                                            } );

--- a/examples/simulator/basicJointVelocity/basicJointVelocity.cpp
+++ b/examples/simulator/basicJointVelocity/basicJointVelocity.cpp
@@ -19,11 +19,11 @@ int main()
         auto endCycleFuture = endCyclePromise.get_future();
 
         localRofi.getJoint( 2 ).setVelocity( speed );
-        RoFI::wait( 1000, [ & ] {
+        RoFI::postpone( 1000, [ & ] {
             localRofi.getJoint( 2 ).setVelocity( -speed );
-            RoFI::wait( 1000, [ & ] {
+            RoFI::postpone( 1000, [ & ] {
                 localRofi.getJoint( 2 ).setVelocity( 0 );
-                RoFI::wait( 1000, [ & ] { endCyclePromise.set_value(); } );
+                RoFI::postpone( 1000, [ & ] { endCyclePromise.set_value(); } );
             } );
         } );
 

--- a/examples/simulator/basicMove/basicMove.cpp
+++ b/examples/simulator/basicMove/basicMove.cpp
@@ -33,13 +33,13 @@ void setToLimitPos( Joint joint, bool max, Callback && callback )
     else
     {
         joint.setVelocity( ( max ? 1 : -1 ) * speed );
-        RoFI::wait( 4000, std::forward< Callback >( callback ) );
+        RoFI::postpone( 4000, std::forward< Callback >( callback ) );
     }
 }
 
 void checkConnected( Connector connector_ )
 {
-    RoFI::wait( 2000, [ connectorConst = connector_ ] {
+    RoFI::postpone( 2000, [ connectorConst = connector_ ] {
         Connector connector = connectorConst;
         auto state = connector.getState();
         if ( state.position != ConnectorPosition::Extended || state.connected )
@@ -50,7 +50,7 @@ void checkConnected( Connector connector_ )
 
         std::cout << "Retracting\n";
         connector.disconnect();
-        RoFI::wait( 2000, [ connectorConst = connector ] {
+        RoFI::postpone( 2000, [ connectorConst = connector ] {
             Connector conn = connectorConst;
             std::cout << "Extending\n";
             conn.connect();
@@ -75,14 +75,8 @@ void oneMove( int connector )
     remoteRofi.getConnector( otherConnector ).disconnect();
 
     // Wait 1 second
-    {
-        std::cout << "Wait for 1s\n";
-        std::promise< void > waitPromise;
-        auto waitFuture = waitPromise.get_future();
-
-        RoFI::wait( 1000, [ &waitPromise ] { waitPromise.set_value(); } );
-        waitFuture.get();
-    }
+    std::cout << "Wait for 1s\n";
+    sleep( 1000 );
 
     // Move joints
     {

--- a/softwareComponents/rofiHalEsp32/src/rofi_hal.cpp
+++ b/softwareComponents/rofiHalEsp32/src/rofi_hal.cpp
@@ -996,6 +996,38 @@ private:
 
 namespace rofi::hal {
 
+void RoFI::wait( int ms, std::function< void() > callback )
+{
+    if ( !callback ) {
+        throw std::invalid_argument( "empty callback" );
+    }
+
+    if ( ms < 0 ) {
+        throw std::invalid_argument( "negative wait time" );
+    }
+
+    vTaskDelay( ms / portTICK_PERIOD_MS );
+    callback();
+}
+
+void RoFI::delay( int ms, std::function< void() > callback )
+{
+    if ( !callback ) {
+        throw std::invalid_argument( "empty callback" );
+    }
+
+    if ( ms < 0 ) {
+        throw std::invalid_argument( "negative wait time" );
+    }
+
+    auto* timer = new rtos::Timer();
+    *timer = rtos::Timer( static_cast< std::chrono::milliseconds >( ms ),
+                          rtos::Timer::Type::OneShot,
+                          [ ptr = timer, cb = std::move( callback ) ]() { cb(); delete ptr; }
+                    );
+    timer->start();
+}
+
 RoFI RoFI::getLocalRoFI() {
     // Definition of local RoFI driver
     static std::shared_ptr< RoFILocal > localRoFI = std::make_shared< RoFILocal >();

--- a/softwareComponents/rofiHalEsp32/src/rofi_hal.cpp
+++ b/softwareComponents/rofiHalEsp32/src/rofi_hal.cpp
@@ -996,21 +996,16 @@ private:
 
 namespace rofi::hal {
 
-void RoFI::wait( int ms, std::function< void() > callback )
+void RoFI::sleep( int ms )
 {
-    if ( !callback ) {
-        throw std::invalid_argument( "empty callback" );
-    }
-
     if ( ms < 0 ) {
-        throw std::invalid_argument( "negative wait time" );
+        throw std::invalid_argument( "negative sleep time" );
     }
 
     vTaskDelay( ms / portTICK_PERIOD_MS );
-    callback();
 }
 
-void RoFI::delay( int ms, std::function< void() > callback )
+void RoFI::postpone( int ms, std::function< void() > callback )
 {
     if ( !callback ) {
         throw std::invalid_argument( "empty callback" );

--- a/softwareComponents/rofiHalInc/include/rofi_hal.hpp
+++ b/softwareComponents/rofiHalInc/include/rofi_hal.hpp
@@ -622,13 +622,22 @@ public:
     void reboot() { return _impl->reboot(); }
 
     /**
-     * \brief Call callback after given delay.
+     * \brief Call callback after given delay. The call is blocking.
      *
      * You can assume that the callback will always be called exactly once.
      * \param ms delay in milliseconds
      * \param callback non-empty callback to be called after the delay
      */
     static void wait( int ms, std::function< void() > callback );
+
+    /**
+     * \brief Call callback after given delay. The call is non-blocking.
+     *
+     * You can assume that the callback will always be called exactly once.
+     * \param ms delay in milliseconds
+     * \param callback non-empty callback to be called after the delay
+     */
+    static void delay( int ms, std::function< void() > callback );
 
 private:
     RoFI( std::shared_ptr< Implementation > impl ) : _impl( std::move( impl ) ) {}

--- a/softwareComponents/rofiHalInc/include/rofi_hal.hpp
+++ b/softwareComponents/rofiHalInc/include/rofi_hal.hpp
@@ -622,22 +622,20 @@ public:
     void reboot() { return _impl->reboot(); }
 
     /**
-     * \brief Call callback after given delay. The call is blocking.
+     * \brief Blocks the execution for given amount of time
      *
-     * You can assume that the callback will always be called exactly once.
      * \param ms delay in milliseconds
-     * \param callback non-empty callback to be called after the delay
      */
-    static void wait( int ms, std::function< void() > callback );
+    static void sleep( int ms );
 
     /**
      * \brief Call callback after given delay. The call is non-blocking.
      *
      * You can assume that the callback will always be called exactly once.
-     * \param ms delay in milliseconds
+     * \param ms wait time in milliseconds
      * \param callback non-empty callback to be called after the delay
      */
-    static void delay( int ms, std::function< void() > callback );
+    static void postpone( int ms, std::function< void() > callback );
 
 private:
     RoFI( std::shared_ptr< Implementation > impl ) : _impl( std::move( impl ) ) {}

--- a/softwareComponents/rofiHalSim/rofi_hal.cpp
+++ b/softwareComponents/rofiHalSim/rofi_hal.cpp
@@ -263,19 +263,16 @@ public:
     void onWaitResp( const msgs::RofiResp & resp );
     void onResponse( const msgs::RofiResp & resp );
 
-    void wait( int ms, std::function< void() > callback )
+    void sleep( int ms )
     {
-        assert( callback );
         assert( ms >= 0 );
 
         auto waitEndPromise = std::promise< void >();
-        delay( static_cast< int >( ms ), [ &waitEndPromise ] { waitEndPromise.set_value(); } );
+        postpone( static_cast< int >( ms ), [ &waitEndPromise ] { waitEndPromise.set_value(); } );
         waitEndPromise.get_future().get();
-
-        callback();
     }
 
-    void delay( int ms, std::function< void() > callback )
+    void postpone( int ms, std::function< void() > callback )
     {
         assert( callback );
         assert( ms >= 0 );
@@ -824,22 +821,18 @@ RoFI RoFI::getRemoteRoFI( RoFI::Id remoteId )
     return RoFI( std::move( remoteRoFI ) );
 }
 
-void RoFI::wait( int ms, std::function< void() > callback )
+void RoFI::sleep( int ms )
 {
-    if ( !callback ) {
-        throw std::invalid_argument( "empty callback" );
-    }
-
     if ( ms < 0 ) {
         throw std::invalid_argument( "negative wait time" );
     }
 
     auto localRoFI = std::dynamic_pointer_cast< RoFISim >( RoFI::getLocalRoFI()._impl );
     assert( localRoFI );
-    localRoFI->wait( ms, std::move( callback ) );
+    localRoFI->sleep( ms );
 }
 
-void RoFI::delay( int ms, std::function< void() > callback )
+void RoFI::postpone( int ms, std::function< void() > callback )
 {
     if ( !callback ) {
         throw std::invalid_argument( "empty callback" );
@@ -851,7 +844,7 @@ void RoFI::delay( int ms, std::function< void() > callback )
 
     auto localRoFI = std::dynamic_pointer_cast< RoFISim >( RoFI::getLocalRoFI()._impl );
     assert( localRoFI );
-    localRoFI->delay( ms, std::move( callback ) );
+    localRoFI->postpone( ms, std::move( callback ) );
 }
 
 } // namespace rofi::hal

--- a/softwareComponents/rofiHalSim/rofi_hal.cpp
+++ b/softwareComponents/rofiHalSim/rofi_hal.cpp
@@ -268,6 +268,18 @@ public:
         assert( callback );
         assert( ms >= 0 );
 
+        auto waitEndPromise = std::promise< void >();
+        delay( static_cast< int >( ms ), [ &waitEndPromise ] { waitEndPromise.set_value(); } );
+        waitEndPromise.get_future().get();
+
+        callback();
+    }
+
+    void delay( int ms, std::function< void() > callback )
+    {
+        assert( callback );
+        assert( ms >= 0 );
+
         int waitId = waitWorker.registerWaitCallback( std::move( callback ) );
 
         msgs::RofiCmd rofiCmd;
@@ -825,6 +837,21 @@ void RoFI::wait( int ms, std::function< void() > callback )
     auto localRoFI = std::dynamic_pointer_cast< RoFISim >( RoFI::getLocalRoFI()._impl );
     assert( localRoFI );
     localRoFI->wait( ms, std::move( callback ) );
+}
+
+void RoFI::delay( int ms, std::function< void() > callback )
+{
+    if ( !callback ) {
+        throw std::invalid_argument( "empty callback" );
+    }
+
+    if ( ms < 0 ) {
+        throw std::invalid_argument( "negative wait time" );
+    }
+
+    auto localRoFI = std::dynamic_pointer_cast< RoFISim >( RoFI::getLocalRoFI()._impl );
+    assert( localRoFI );
+    localRoFI->delay( ms, std::move( callback ) );
 }
 
 } // namespace rofi::hal

--- a/softwareComponents/rofiHalSimPy/hal.cpp
+++ b/softwareComponents/rofiHalSimPy/hal.cpp
@@ -78,6 +78,7 @@ PYBIND11_MODULE( pyRofiHal, m ) {
         .def( "getConnector", &RoFI::getConnector )
         .def_property_readonly( "descriptor", &RoFI::getDescriptor )
         .def( "wait", &RoFI::wait )
+        .def( "delay", &RoFI::delay )
         .def_static( "getLocal", &RoFI::getLocalRoFI )
         .def_static( "getRemote", &RoFI::getRemoteRoFI );
 

--- a/softwareComponents/rofiHalSimPy/hal.cpp
+++ b/softwareComponents/rofiHalSimPy/hal.cpp
@@ -77,8 +77,8 @@ PYBIND11_MODULE( pyRofiHal, m ) {
         .def( "getJoint", &RoFI::getJoint )
         .def( "getConnector", &RoFI::getConnector )
         .def_property_readonly( "descriptor", &RoFI::getDescriptor )
-        .def( "wait", &RoFI::wait )
-        .def( "delay", &RoFI::delay )
+        .def( "sleep", &RoFI::sleep )
+        .def( "postpone", &RoFI::postpone )
         .def_static( "getLocal", &RoFI::getLocalRoFI )
         .def_static( "getRemote", &RoFI::getRemoteRoFI );
 

--- a/tutorials/simulator/task_3_solution/module_code.cpp
+++ b/tutorials/simulator/task_3_solution/module_code.cpp
@@ -9,15 +9,6 @@
 namespace hal = rofi::hal;
 using namespace std::chrono_literals;
 
-void blockingWait( std::chrono::milliseconds delayMs )
-{
-    auto waitEndPromise = std::promise< void >();
-
-    hal::RoFI::wait( static_cast< int >( delayMs.count() ), [ & ] { waitEndPromise.set_value(); } );
-
-    waitEndPromise.get_future().get();
-}
-
 void blockingMove( hal::Joint joint, Angle pos, float speedMultiplier = 0.8f )
 {
     auto moveEndPromise = std::promise< void >();

--- a/tutorials/simulator/task_4_solution/module_code.cpp
+++ b/tutorials/simulator/task_4_solution/module_code.cpp
@@ -11,15 +11,6 @@
 namespace hal = rofi::hal;
 using namespace std::chrono_literals;
 
-void blockingWait( std::chrono::milliseconds delayMs )
-{
-    auto waitEndPromise = std::promise< void >();
-
-    hal::RoFI::wait( static_cast< int >( delayMs.count() ), [ & ] { waitEndPromise.set_value(); } );
-
-    waitEndPromise.get_future().get();
-}
-
 void blockingMove( hal::Joint joint, Angle pos, float speedMultiplier = 0.8f )
 {
     auto moveEndPromise = std::promise< void >();

--- a/tutorials/simulator/task_5_solution/module_code.cpp
+++ b/tutorials/simulator/task_5_solution/module_code.cpp
@@ -11,15 +11,6 @@
 namespace hal = rofi::hal;
 using namespace std::chrono_literals;
 
-void blockingWait( std::chrono::milliseconds delayMs )
-{
-    auto waitEndPromise = std::promise< void >();
-
-    hal::RoFI::wait( static_cast< int >( delayMs.count() ), [ & ] { waitEndPromise.set_value(); } );
-
-    waitEndPromise.get_future().get();
-}
-
 void blockingMove( hal::Joint joint, Angle pos, float speedMultiplier = 0.8f )
 {
     auto moveEndPromise = std::promise< void >();
@@ -169,7 +160,7 @@ int main()
     bool isMaster = blockingConnectAndSelectMaster( connectorA, localRoFI.getId() );
     // Don't do blocking disconnect because the second one could set the callback too late
     connectorA.disconnect();
-    blockingWait( 500ms );
+    sleep( 500 );
 
     if ( isMaster ) {
         std::cout << "I am master\n";

--- a/tutorials/simulator/task_6_solution/module_code.cpp
+++ b/tutorials/simulator/task_6_solution/module_code.cpp
@@ -9,15 +9,6 @@
 namespace hal = rofi::hal;
 using namespace std::chrono_literals;
 
-void blockingWait( std::chrono::milliseconds delayMs )
-{
-    auto waitEndPromise = std::promise< void >();
-
-    hal::RoFI::wait( static_cast< int >( delayMs.count() ), [ & ] { waitEndPromise.set_value(); } );
-
-    waitEndPromise.get_future().get();
-}
-
 hal::PBuf createPacket( const std::string & message )
 {
     auto packet = hal::PBuf::allocate( int( message.size() ) );
@@ -48,7 +39,7 @@ int main()
     } );
 
     for ( int i = 0; true; i++ ) {
-        blockingWait( 1s );
+        sleep( 1000 );
         connector.send( 1, createPacket( "Message no. " + std::to_string( i ) ) );
     }
 }


### PR DESCRIPTION
This PR

 * adds a new non-blocking variant for `wait` function – `delay`;
 * implements `wait` and `delay` for esp32;
 * fixes non-blocking `wait` behaviour in the SimpleSim (You can check the behaviour using tutorial 2 by adding `wait`/`delay` before the Hello, World!).