### PR TITLE
Simplesim - optional collision detection

### DIFF
--- a/softwareComponents/simplesimClientLib/include/simplesim_client.hpp
+++ b/softwareComponents/simplesimClientLib/include/simplesim_client.hpp
@@ -97,7 +97,7 @@ public:
             std::shared_ptr< const rofi::configuration::RofiWorld > newConfiguration )
     {
         assert( newConfiguration );
-        assert( newConfiguration->isValid( rofi::configuration::SimpleCollision() ) );
+        assert( newConfiguration->isValid( rofi::configuration::NoCollision() ) );
         _currentConfiguration.replace( std::move( newConfiguration ) );
     }
 

--- a/softwareComponents/simplesimLib/include/simplesim/collision.hpp
+++ b/softwareComponents/simplesimLib/include/simplesim/collision.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <configuration/rofiworld.hpp>
+#include <atoms/result.hpp>
+
+namespace rofi::simplesim {
+
+enum class CollisionModel {
+    None,
+    Simple
+};  
+
+// Shared ptr to the specified collision model
+atoms::Result< std::shared_ptr< rofi::configuration::Collision > > getCollisionPtr( CollisionModel collType ) {
+    std::shared_ptr< rofi::configuration::Collision > collModel;
+    switch (collType) {
+    case CollisionModel::None:
+        collModel = std::make_shared< rofi::configuration::NoCollision >();
+        return atoms::result_value( collModel );
+    case CollisionModel::Simple:
+        collModel = std::make_shared< rofi::configuration::SimpleCollision >();
+        return atoms::result_value( collModel );
+    default:
+        return atoms::result_error< std::string >( "Invalid collision model" );
+    }
+}
+
+} // namespace rofi::simplesim

--- a/softwareComponents/simplesimLib/include/simplesim/module_states.hpp
+++ b/softwareComponents/simplesimLib/include/simplesim/module_states.hpp
@@ -251,7 +251,9 @@ public:
     using RofiWorldConfigurationPtr = std::shared_ptr< const rofi::configuration::RofiWorld >;
 
 
-    explicit ModuleStates( RofiWorldConfigurationPtr rofiworldConfiguration, bool verbose )
+    explicit ModuleStates( RofiWorldConfigurationPtr rofiworldConfiguration, 
+                           std::shared_ptr< rofi::configuration::Collision > collModel,
+                           bool verbose )
             : _physicalModulesConfiguration(
                     rofiworldConfiguration
                             ? std::move( rofiworldConfiguration )
@@ -261,10 +263,11 @@ public:
                           assert( configPtr );
                           return initInnerStatesFromConfiguration( *configPtr, verbose );
                       } ) )
+            , _collModel( collModel )
     {
-        assert( _physicalModulesConfiguration.visit( []( const auto & configuration ) {
+        assert( _physicalModulesConfiguration.visit( [ &collModel ]( const auto & configuration ) {
             assert( configuration );
-            return configuration->isValid( rofi::configuration::SimpleCollision() );
+            return configuration->isValid( *collModel );
         } ) );
     }
 
@@ -369,6 +372,7 @@ private:
 private:
     atoms::Guarded< RofiWorldConfigurationPtr > _physicalModulesConfiguration;
     std::map< ModuleId, ModuleInnerState > _moduleInnerStates;
+    std::shared_ptr< rofi::configuration::Collision > _collModel;
 
     atoms::Guarded< std::vector< RofiWorldConfigurationPtr > > _configurationHistory;
 };

--- a/softwareComponents/simplesimLib/include/simplesim/simplesim.hpp
+++ b/softwareComponents/simplesimLib/include/simplesim/simplesim.hpp
@@ -88,9 +88,11 @@ public:
 
     Simplesim( std::shared_ptr< const rofi::configuration::RofiWorld > worldConfiguration,
                PacketFilter::FilterFunction packetFilter,
+               std::shared_ptr< rofi::configuration::Collision > collModel,
                bool verbose )
             : _simulation( std::make_shared< Simulation >( std::move( worldConfiguration ),
                                                            std::move( packetFilter ),
+                                                           std::move( collModel ),
                                                            verbose ) )
             , _communication(
                       std::make_shared< Communication >( _simulation->commandHandler(), verbose ) )

--- a/softwareComponents/simplesimLib/include/simplesim/simulation.hpp
+++ b/softwareComponents/simplesimLib/include/simplesim/simulation.hpp
@@ -29,9 +29,12 @@ public:
 
     explicit Simulation( std::shared_ptr< const rofi::configuration::RofiWorld > rofiworldConfiguration,
                          PacketFilter::FilterFunction packetFilter,
+                         std::shared_ptr< rofi::configuration::Collision > collModel,
                          bool verbose )
             : _moduleStates(
-                    std::make_shared< ModuleStates >( std::move( rofiworldConfiguration ), verbose ) )
+                    std::make_shared< ModuleStates >( std::move( rofiworldConfiguration ), 
+                                                      std::move( collModel ), 
+                                                      verbose ) )
             , _commandHandler( std::make_shared< CommandHandler >( this->_moduleStates,
                                                                    std::move( packetFilter ) ) )
     {

--- a/softwareComponents/simplesimLib/src/module_states.cpp
+++ b/softwareComponents/simplesimLib/src/module_states.cpp
@@ -336,7 +336,7 @@ auto ModuleStates::computeNextIteration( std::chrono::duration< float > simStepT
     // Workaround for a bug in configuration (not setting the prepared flag properly)
     newConfiguration->prepare().get_or_throw_as< std::logic_error >();
 
-    if ( auto ok = newConfiguration->validate( SimpleCollision{} ); !ok ) {
+    if ( auto ok = newConfiguration->validate( *_collModel ); !ok ) {
         std::cerr << "Error after joint update: '" << ok.assume_error() << "'\n";
         throw std::runtime_error( std::move( ok ).assume_error() );
     }
@@ -346,7 +346,7 @@ auto ModuleStates::computeNextIteration( std::chrono::duration< float > simStepT
             connectorUpdateEvents.connectorsToFinalizePosition );
     updateEvents.connectionsChanged = std::move( connectorUpdateEvents.connectionsChanged );
 
-    if ( auto ok = newConfiguration->validate( SimpleCollision{} ); !ok ) {
+    if ( auto ok = newConfiguration->validate( *_collModel ); !ok ) {
         std::cerr << "Error after connector update: '" << ok.assume_error() << "'\n";
         throw std::runtime_error( std::move( ok ).assume_error() );
     }

--- a/softwareComponents/simplesimServerLib/include/simplesim_server.hpp
+++ b/softwareComponents/simplesimServerLib/include/simplesim_server.hpp
@@ -34,6 +34,13 @@ public:
                 .desc( "Python packet filter file" );
 
         cli.opt( &verbose, "v verbose" ).desc( "Run simulator in verbose mode" );
+
+        cli.opt( &collision, "c collision", CollisionModel::Simple )
+                .desc( "Collision model to use")
+                .choice( CollisionModel::None, 
+                    "none", "No collision detection" )
+                .choice( CollisionModel::Simple, 
+                    "simple", "Simple collision - each component is a unit sphere");
     }
 
     auto readInputWorldFile() const -> atoms::Result< rofi::configuration::RofiWorld >
@@ -63,6 +70,7 @@ public:
     std::optional< std::filesystem::path > pyPacketFilterFile = {};
 
     bool verbose = {};
+    CollisionModel collision = CollisionModel::Simple;
 };
 
 } // namespace rofi::simplesim

--- a/tools/simplesimClient/main.cpp
+++ b/tools/simplesimClient/main.cpp
@@ -59,7 +59,7 @@ private:
                 configuration::serialization::fromJSON( nlohmann::json::parse( msg->value() ) ) );
         assert( rofiworld );
 
-        if ( auto ok = rofiworld->validate( configuration::SimpleCollision() ); !ok ) {
+        if ( auto ok = rofiworld->validate( configuration::NoCollision() ); !ok ) {
             std::cerr << "Configuration not valid: '" << ok.assume_error() << "'" << std::endl;
             return;
         }


### PR DESCRIPTION
Add the --collision option to simplesim, which turns on collision detection (as of now, simplesim terminates when it detects a collision; without using this option, simplesim will just ignore any collisions and it will render even physically impossible movement); can be used for debugging scripts.