### PR TITLE
Simulator command line

### DIFF
--- a/softwareComponents/rofiHalSim/connector_worker.hpp
+++ b/softwareComponents/rofiHalSim/connector_worker.hpp
@@ -112,6 +112,8 @@ private:
                 return ConnectorEvent::Disconnected;
             case ConnectorCmd::POWER_CHANGED:
                 return ConnectorEvent::PowerChanged;
+            default:
+                break;
         }
         ROFI_UNREACHABLE( "Unknown connector event type" );
     }
@@ -163,6 +165,8 @@ private:
                 } );
                 return;
             }
+            default:
+                break;
         }
         ROFI_UNREACHABLE( "Unknown connector response type" );
     }

--- a/softwareComponents/rofiHalSim/publish_worker.hpp
+++ b/softwareComponents/rofiHalSim/publish_worker.hpp
@@ -109,9 +109,18 @@ private:
             return it->second;
         }
 
+        // Subscribe to ~/distributor/response before sending to ~/distributor/request
+        auto sub = PublishWorker::get().subscribe(
+                [ & ]( auto resp ) { std::cout << "Subscribed to response\n"; } );
+
+        // Lock the module if not locked already
         rofi::messages::DistributorReq req;
-        req.set_reqtype( rofi::messages::DistributorReq::GET_INFO );
+        req.set_reqtype( rofi::messages::DistributorReq::TRY_LOCK );
         req.set_sessionid( SessionId::get().bytes() );
+        req.set_rofiid( rofiId );
+        publish( std::move( req ) );
+
+        req.set_reqtype( rofi::messages::DistributorReq::GET_INFO );
         publish( std::move( req ) );
 
         _onRofiTopicsUpdate.wait( lock, [ this, rofiId ] {

--- a/softwareComponents/simplesimClientLib/CMakeLists.txt
+++ b/softwareComponents/simplesimClientLib/CMakeLists.txt
@@ -5,6 +5,7 @@ set(RESOURCE_FILES
     model/body.obj
     model/connector.obj
     model/shoe.obj
+    model/cube.obj
 )
 
 set(FILES

--- a/softwareComponents/simplesimClientLib/src/simplesim_client.cpp
+++ b/softwareComponents/simplesimClientLib/src/simplesim_client.cpp
@@ -476,8 +476,10 @@ void SimplesimClient::initInfoTree( const rofi::configuration::RofiWorld & rofiw
             _ui->treeWidget->addTopLevelItem( qtModule );
         }
         QTreeWidgetItem * components = new QTreeWidgetItem( qtModule, { QString( "Components" ) } );
+        int compInd = 0;
         for ( const auto & c : rModule.components() ) {
-            std::string comp = rofi::configuration::serialization::componentTypeToString( c.type );
+            std::string comp = std::to_string(compInd) + " " + rofi::configuration::serialization::componentTypeToString( c.type );
+            ++compInd;
             new QTreeWidgetItem( components, { QString( comp.c_str() ) } );
         }
         if ( auto * universalModule = dynamic_cast< const UniversalModule * >( &rModule ) ) {

--- a/softwareComponents/simplesimClientLib/src/simplesim_client.cpp
+++ b/softwareComponents/simplesimClientLib/src/simplesim_client.cpp
@@ -69,6 +69,7 @@ vtkAlgorithmOutput * getComponentModel( rofi::configuration::ComponentType type 
             { ComponentType::Roficom, LOAD_RESOURCE_FILE_LAZY( model_connector_obj ) },
             { ComponentType::UmBody, LOAD_RESOURCE_FILE_LAZY( model_body_obj ) },
             { ComponentType::UmShoe, LOAD_RESOURCE_FILE_LAZY( model_shoe_obj ) },
+            { ComponentType::CubeBody, LOAD_RESOURCE_FILE_LAZY( model_cube_obj ) },
     } );
     static std::map< ComponentType, vtkSmartPointer< vtkTransformPolyDataFilter > > cache;
 

--- a/tools/gazebosimTools/CMakeLists.txt
+++ b/tools/gazebosimTools/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(rofi-sim-ping ping.cpp)
 target_link_libraries(rofi-sim-ping rofi::hal)
 
 add_executable(rofi-sim-commandLine commandLine.cpp)
-target_link_libraries(rofi-sim-commandLine PRIVATE rofi::hal ${GAZEBO_LIBRARIES})
+target_link_libraries(rofi-sim-commandLine PRIVATE rofi::hal ${GAZEBO_LIBRARIES} atoms)
 target_include_directories(rofi-sim-commandLine SYSTEM PRIVATE ${GAZEBO_INCLUDE_DIRS})
 
 add_executable(rofi-sim-roficomCmd roficomCmd.cpp)

--- a/tools/gazebosimTools/commandLine.cpp
+++ b/tools/gazebosimTools/commandLine.cpp
@@ -301,7 +301,7 @@ void processJointCmd( rofi::hal::RoFI & rofi, const std::vector< std::string_vie
                 throw std::runtime_error( "Wrong number of arguments" );
             }
             int job = Jobs::get().startNew();
-            joint.setPosition( readFloat( tokens[ 3 ] ),
+            joint.setPosition( Angle::deg( readFloat( tokens[ 3 ] ) ).rad(),
                                readFloat( tokens[ 4 ] ),
                                [ job ]( rofi::hal::Joint ) 
                                 { 

--- a/tools/rofiTool/CMakeLists.txt
+++ b/tools/rofiTool/CMakeLists.txt
@@ -6,6 +6,7 @@ add_resources(MODEL_RESOURCES
     "model/connector.obj"
     "model/shoe.obj"
     "model/point.obj"
+    "model/cube.obj"
 )
 
 set(ROFI_TOOL_SRCS

--- a/tools/rofiTool/rendering.cpp
+++ b/tools/rofiTool/rendering.cpp
@@ -59,6 +59,7 @@ vtkAlgorithmOutput * getComponentModel( ComponentType type )
             { ComponentType::Roficom, LOAD_RESOURCE_FILE_LAZY( model_connector_obj ) },
             { ComponentType::UmBody, LOAD_RESOURCE_FILE_LAZY( model_body_obj ) },
             { ComponentType::UmShoe, LOAD_RESOURCE_FILE_LAZY( model_shoe_obj ) },
+            { ComponentType::CubeBody, LOAD_RESOURCE_FILE_LAZY( model_cube_obj ) },
     } );
     static std::map< ComponentType, vtkSmartPointer< vtkTransformPolyDataFilter > > cache;
 

--- a/tools/visualizer/CMakeLists.txt
+++ b/tools/visualizer/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.6)
 project(rofi)
 
 
-add_resources(modelResources "model/body.obj" "model/connector.obj" "model/shoe.obj")
+add_resources(modelResources "model/body.obj" "model/connector.obj" "model/shoe.obj" "model/cube.obj" "model/point.obj")
 
 message("Model resources: ${modelResources}")
 


### PR DESCRIPTION
Adds module selection to the rofi-sim-commandLine tool, so it can be used to control all modules in the simulated configuration.
Adds the ability to log//parse commands to/from files, which can be used to execute scripts for the simulation. 
Add the cube model to rofi-tool and rofi-simplesim.
Enumerate roficoms in simplesim component tree