### PR TITLE
releng: Fix calling of cleanSuite in rmake

### DIFF
--- a/releng/tools/rmake
+++ b/releng/tools/rmake
@@ -154,7 +154,7 @@ def build(patterns, maxThreads):
     targetsToCompile.sort(key=lambda x: x.suite)
 
     for s in suitesToClean:
-        cleanSuite(s, maxThreads)
+        cleanSuite(s)
 
     for s in suitesToCompile:
         compileSuite(s, maxThreads)
@@ -196,7 +196,7 @@ def test(patterns, maxThreads):
     targetsToCompile.sort(key=lambda x: x.suite)
 
     for s in suitesToClean:
-        cleanSuite(s, maxThreads)
+        cleanSuite(s)
 
     compileTargets(targetsToCompile, maxThreads)
 


### PR DESCRIPTION
`cleanSuite` does not take thread count as a parameter, so `rmake clean` results in an error.